### PR TITLE
Check for existing account during configuration and update translation messages

### DIFF
--- a/custom_components/webastoconnect/config_flow.py
+++ b/custom_components/webastoconnect/config_flow.py
@@ -32,6 +32,9 @@ class WebastoConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
+            if any(entry.data[CONF_EMAIL] == user_input[CONF_EMAIL] for entry in self._async_current_entries()):
+                return self.async_abort(reason="already_configured")
+            
             try:
                 webasto = WebastoConnect(
                     user_input[CONF_EMAIL], user_input[CONF_PASSWORD]

--- a/custom_components/webastoconnect/translations/da.json
+++ b/custom_components/webastoconnect/translations/da.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Enheden er allerede konfigureret"
+            "already_configured": "Denne konto er allerede tilføjet"
         },
         "error": {
             "invalid_auth": "Ugyldig autentificering"

--- a/custom_components/webastoconnect/translations/en.json
+++ b/custom_components/webastoconnect/translations/en.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "This account is already configured"
         },
         "error": {
             "invalid_auth": "Invalid authentication"


### PR DESCRIPTION
Implement a check to prevent configuring an account that already exists and update the translation messages for clarity.