### PR TITLE
Guard device tracker against invalid location payloads

### DIFF
--- a/custom_components/webastoconnect/device_tracker.py
+++ b/custom_components/webastoconnect/device_tracker.py
@@ -26,7 +26,7 @@ TRACKER = EntityDescription(
 
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):
-    """Setup device tracker."""
+    """Set up device tracker."""
     coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
     trackers = []
 
@@ -57,10 +57,21 @@ class WebastoConnectDeviceTracker(WebastoBaseEntity, TrackerEntity):
             )
         )
 
-        self._prev_lat = self._cloud.devices[self._device_id].location["lat"]  # type: ignore
-        self._prev_lon = self._cloud.devices[self._device_id].location["lon"]  # type: ignore
+        location = self._location_data
+        self._prev_lat = location["lat"] if location else None
+        self._prev_lon = location["lon"] if location else None
 
         self._attributes = {}
+
+    @property
+    def _location_data(self) -> dict | None:
+        """Return validated location data when available."""
+        location = self._cloud.devices[self._device_id].location
+        if not isinstance(location, dict):
+            return None
+        if "lat" not in location or "lon" not in location:
+            return None
+        return location
 
     @property
     def extra_state_attributes(self):
@@ -70,22 +81,20 @@ class WebastoConnectDeviceTracker(WebastoBaseEntity, TrackerEntity):
     @property
     def available(self) -> bool:
         """Handle the location states."""
-        if isinstance(self._cloud.devices[self._device_id].location, type(None)):
-            self._attr_available = False
-            return False
-        else:
-            self._attr_available = True
-            return True
+        is_available = self._location_data is not None
+        self._attr_available = is_available
+        return is_available
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        if (
-            self._cloud.devices[self._device_id].location["lat"] != self._prev_lat  # type: ignore
-            or self._cloud.devices[self._device_id].location["lon"] != self._prev_lon  # type: ignore
-        ):
-            self._prev_lat = self._cloud.devices[self._device_id].location["lat"]  # type: ignore
-            self._prev_lon = self._cloud.devices[self._device_id].location["lon"]  # type: ignore
+        location = self._location_data
+        lat = location["lat"] if location else None
+        lon = location["lon"] if location else None
+
+        if lat != self._prev_lat or lon != self._prev_lon:
+            self._prev_lat = lat
+            self._prev_lon = lon
             self._attributes = {}
 
             self.async_write_ha_state()
@@ -93,7 +102,7 @@ class WebastoConnectDeviceTracker(WebastoBaseEntity, TrackerEntity):
     @property
     def source_type(self) -> SourceType | str | None:
         """Return the source type, eg gps or router, of the device."""
-        if isinstance(self._cloud.devices[self._device_id].location, type(None)):
+        if self._location_data is None:
             return None
 
         return SourceType.GPS
@@ -101,15 +110,17 @@ class WebastoConnectDeviceTracker(WebastoBaseEntity, TrackerEntity):
     @property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
-        if isinstance(self._cloud.devices[self._device_id].location, type(None)):
+        location = self._location_data
+        if location is None:
             return None
 
-        return float(self._cloud.devices[self._device_id].location["lat"])  # type: ignore
+        return float(location["lat"])
 
     @property
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
-        if isinstance(self._cloud.devices[self._device_id].location, type(None)):
+        location = self._location_data
+        if location is None:
             return None
 
-        return float(self._cloud.devices[self._device_id].location["lon"])  # type: ignore
+        return float(location["lon"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for local integration tests."""
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/test_device_tracker_location.py
+++ b/tests/test_device_tracker_location.py
@@ -1,0 +1,50 @@
+"""Tests for Webasto device tracker location guards."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from custom_components.webastoconnect.device_tracker import WebastoConnectDeviceTracker
+
+
+def _build_tracker(location, prev_lat=None, prev_lon=None) -> WebastoConnectDeviceTracker:
+    """Create a minimal tracker instance for unit tests."""
+    tracker = object.__new__(WebastoConnectDeviceTracker)
+    tracker._device_id = 1
+    tracker._cloud = SimpleNamespace(devices={1: SimpleNamespace(location=location)})
+    tracker._prev_lat = prev_lat
+    tracker._prev_lon = prev_lon
+    tracker._attributes = {}
+    tracker._attr_available = True
+    tracker.async_write_ha_state = Mock()
+    return tracker
+
+
+def test_tracker_location_false_is_unavailable() -> None:
+    """Tracker should be unavailable when location data is disabled."""
+    tracker = _build_tracker(False)
+
+    assert tracker.available is False
+    assert tracker.source_type is None
+    assert tracker.latitude is None
+    assert tracker.longitude is None
+
+
+def test_tracker_location_without_coords_is_unavailable() -> None:
+    """Tracker should be unavailable when lat/lon are missing."""
+    tracker = _build_tracker({"state": "ON"})
+
+    assert tracker.available is False
+    assert tracker.latitude is None
+    assert tracker.longitude is None
+
+
+def test_tracker_update_writes_state_when_location_changes() -> None:
+    """Tracker should update cached coords and write state on change."""
+    tracker = _build_tracker({"lat": 55.0, "lon": 12.0}, prev_lat=54.9, prev_lon=12.0)
+
+    tracker._handle_coordinator_update()
+
+    assert tracker._prev_lat == 55.0
+    assert tracker._prev_lon == 12.0
+    tracker.async_write_ha_state.assert_called_once()
+


### PR DESCRIPTION
## Description
- harden `device_tracker` location handling in `custom_components/webastoconnect/device_tracker.py`
- guard against disabled/missing location payloads (for example `False` or dicts without `lat`/`lon`)
- avoid direct indexing on invalid location values during coordinator updates
- keep tracker availability/source_type/coordinates consistent when location data is unavailable

## Test strategy
- run `ruff check custom_components/webastoconnect/device_tracker.py tests/conftest.py tests/test_device_tracker_location.py`
- run `pytest -q tests/test_device_tracker_location.py`

## Known limitations
- tests cover unit-level location guard behavior only
- no live device validation included in this PR

## Required configuration changes
- none
