### PR TITLE
Avoid redundant coordinator refresh after write calls

### DIFF
--- a/custom_components/webastoconnect/number.py
+++ b/custom_components/webastoconnect/number.py
@@ -46,7 +46,7 @@ NUMBERS = [
 
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):
-    """Setup switch."""
+    """Set up numbers."""
     numbers_list = []
 
     coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
@@ -101,4 +101,4 @@ class WebastoConnectNumber(WebastoBaseEntity, NumberEntity):
             self._cloud.devices[self._device_id],
             value,
         )
-        await self.coordinator.async_refresh()
+        self.coordinator.async_update_listeners()

--- a/custom_components/webastoconnect/switch.py
+++ b/custom_components/webastoconnect/switch.py
@@ -56,7 +56,7 @@ SWITCHES = [
 
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):
-    """Setup switch."""
+    """Set up switches."""
     switches = []
 
     coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
@@ -133,7 +133,7 @@ class WebastoConnectSwitch(WebastoBaseEntity, SwitchEntity):
             self._cloud.devices[self._device_id],
             True,
         )
-        await self.coordinator.async_refresh()
+        self.coordinator.async_update_listeners()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
@@ -143,4 +143,4 @@ class WebastoConnectSwitch(WebastoBaseEntity, SwitchEntity):
             self._cloud.devices[self._device_id],
             False,
         )
-        await self.coordinator.async_refresh()
+        self.coordinator.async_update_listeners()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for local integration tests."""
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/test_write_updates_without_refresh.py
+++ b/tests/test_write_updates_without_refresh.py
@@ -1,0 +1,76 @@
+"""Tests for write paths that avoid redundant coordinator refreshes."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.webastoconnect.number import WebastoConnectNumber
+from custom_components.webastoconnect.switch import WebastoConnectSwitch
+
+
+@pytest.mark.asyncio
+async def test_switch_turn_on_updates_listeners_without_refresh() -> None:
+    """Switch turn_on should notify listeners and skip extra refresh."""
+    command_fn = AsyncMock()
+    coordinator = SimpleNamespace(
+        async_update_listeners=Mock(),
+        async_refresh=AsyncMock(),
+    )
+    switch = object.__new__(WebastoConnectSwitch)
+    switch.entity_id = "switch.test"
+    switch.entity_description = SimpleNamespace(command_fn=command_fn)
+    switch._cloud = SimpleNamespace(devices={1: object()})
+    switch._device_id = 1
+    switch.coordinator = coordinator
+
+    await switch.async_turn_on()
+
+    command_fn.assert_awaited_once_with(switch._cloud, switch._cloud.devices[1], True)
+    coordinator.async_update_listeners.assert_called_once()
+    coordinator.async_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_switch_turn_off_updates_listeners_without_refresh() -> None:
+    """Switch turn_off should notify listeners and skip extra refresh."""
+    command_fn = AsyncMock()
+    coordinator = SimpleNamespace(
+        async_update_listeners=Mock(),
+        async_refresh=AsyncMock(),
+    )
+    switch = object.__new__(WebastoConnectSwitch)
+    switch.entity_id = "switch.test"
+    switch.entity_description = SimpleNamespace(command_fn=command_fn)
+    switch._cloud = SimpleNamespace(devices={1: object()})
+    switch._device_id = 1
+    switch.coordinator = coordinator
+
+    await switch.async_turn_off()
+
+    command_fn.assert_awaited_once_with(switch._cloud, switch._cloud.devices[1], False)
+    coordinator.async_update_listeners.assert_called_once()
+    coordinator.async_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_number_set_value_updates_listeners_without_refresh() -> None:
+    """Number writes should notify listeners and skip extra refresh."""
+    set_fn = AsyncMock()
+    coordinator = SimpleNamespace(
+        async_update_listeners=Mock(),
+        async_refresh=AsyncMock(),
+    )
+    number = object.__new__(WebastoConnectNumber)
+    number.entity_id = "number.test"
+    number.entity_description = SimpleNamespace(set_fn=set_fn)
+    number._cloud = SimpleNamespace(devices={1: object()})
+    number._device_id = 1
+    number.coordinator = coordinator
+
+    await number.async_set_native_value(12.5)
+
+    set_fn.assert_awaited_once_with(number._cloud.devices[1], 12.5)
+    coordinator.async_update_listeners.assert_called_once()
+    coordinator.async_refresh.assert_not_called()
+


### PR DESCRIPTION
## Description
- optimize write paths in `switch` and `number` entities to avoid redundant cloud refreshes
- replace post-write `coordinator.async_refresh()` with `coordinator.async_update_listeners()`
- keep immediate state propagation to entities without forcing an extra network poll after each write

## Test strategy
- run `ruff check custom_components/webastoconnect/switch.py custom_components/webastoconnect/number.py tests/conftest.py tests/test_write_updates_without_refresh.py`
- run `pytest -q tests/test_write_updates_without_refresh.py`

## Known limitations
- this PR validates write-path behavior at unit level only
- overall polling cadence and cloud client behavior are unchanged

## Required configuration changes
- none
