### PR TITLE
Enhance cloud-call serialization to prevent active-device races

### DIFF
--- a/custom_components/webastoconnect/api.py
+++ b/custom_components/webastoconnect/api.py
@@ -1,7 +1,9 @@
 """API connector class."""
 
+import asyncio
 import logging
 from datetime import datetime, timedelta
+from typing import Any, Awaitable, Callable, TypeVar
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -17,6 +19,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 UNAUTHORIZED_RETRY_AFTER = 5
 MAX_CONSECUTIVE_UNAUTHORIZED = 3
 LOGGER = logging.getLogger(__name__)
+_T = TypeVar("_T")
 
 
 class WebastoConnector:
@@ -51,12 +54,23 @@ class WebastoConnectUpdateCoordinator(DataUpdateCoordinator[None]):
             entry.options.get(CONF_PASSWORD, entry.data.get(CONF_PASSWORD)),
         )
         self._consecutive_unauthorized = 0
+        self._cloud_operation_lock = asyncio.Lock()
+
+    async def async_execute_cloud_call(
+        self,
+        cloud_call: Callable[..., Awaitable[_T]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        """Serialize cloud operations to avoid device context races."""
+        async with self._cloud_operation_lock:
+            return await cloud_call(*args, **kwargs)
 
     async def _async_update_data(self) -> datetime | None:
         """Handle data update request from the coordinator."""
         LOGGER.debug("Data update called")
         try:
-            await self.cloud.update()
+            await self.async_execute_cloud_call(self.cloud.update)
             self._consecutive_unauthorized = 0
         except UnauthorizedException as err:
             self._consecutive_unauthorized += 1

--- a/custom_components/webastoconnect/number.py
+++ b/custom_components/webastoconnect/number.py
@@ -97,7 +97,8 @@ class WebastoConnectNumber(WebastoBaseEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
         LOGGER.debug("Setting '%s' to '%s'", self.entity_id, value)
-        await self.entity_description.set_fn(  # type: ignore
+        await self.coordinator.async_execute_cloud_call(
+            self.entity_description.set_fn,  # type: ignore[arg-type]
             self._cloud.devices[self._device_id],
             value,
         )

--- a/custom_components/webastoconnect/switch.py
+++ b/custom_components/webastoconnect/switch.py
@@ -128,7 +128,8 @@ class WebastoConnectSwitch(WebastoBaseEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         LOGGER.debug("Turning on %s", self.entity_id)
-        await self.entity_description.command_fn(  # type: ignore
+        await self.coordinator.async_execute_cloud_call(
+            self.entity_description.command_fn,  # type: ignore[arg-type]
             self._cloud,
             self._cloud.devices[self._device_id],
             True,
@@ -138,7 +139,8 @@ class WebastoConnectSwitch(WebastoBaseEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
         LOGGER.debug("Turning off %s", self.entity_id)
-        await self.entity_description.command_fn(  # type: ignore
+        await self.coordinator.async_execute_cloud_call(
+            self.entity_description.command_fn,  # type: ignore[arg-type]
             self._cloud,
             self._cloud.devices[self._device_id],
             False,

--- a/tests/test_api_coordinator.py
+++ b/tests/test_api_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for Webasto coordinator update handling."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -20,6 +21,7 @@ def _build_coordinator(update_mock: AsyncMock) -> WebastoConnectUpdateCoordinato
     coordinator = object.__new__(WebastoConnectUpdateCoordinator)
     coordinator.cloud = SimpleNamespace(update=update_mock)
     coordinator._consecutive_unauthorized = 0
+    coordinator._cloud_operation_lock = asyncio.Lock()
     return coordinator
 
 

--- a/tests/test_coordinator_cloud_lock.py
+++ b/tests/test_coordinator_cloud_lock.py
@@ -1,0 +1,44 @@
+"""Tests for serialized Webasto cloud operations."""
+
+import asyncio
+
+import pytest
+
+from custom_components.webastoconnect.api import WebastoConnectUpdateCoordinator
+
+
+def _build_coordinator() -> WebastoConnectUpdateCoordinator:
+    """Create a coordinator with only the lock state needed for tests."""
+    coordinator = object.__new__(WebastoConnectUpdateCoordinator)
+    coordinator._cloud_operation_lock = asyncio.Lock()
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_async_execute_cloud_call_serializes_parallel_calls() -> None:
+    """Parallel cloud calls must execute one at a time."""
+    coordinator = _build_coordinator()
+    order: list[str] = []
+    running = False
+    overlap_detected = False
+
+    async def cloud_call(marker: str) -> None:
+        nonlocal running, overlap_detected
+        if running:
+            overlap_detected = True
+        running = True
+        order.append(f"start-{marker}")
+        await asyncio.sleep(0.01)
+        order.append(f"end-{marker}")
+        running = False
+
+    await asyncio.gather(
+        coordinator.async_execute_cloud_call(cloud_call, "a"),
+        coordinator.async_execute_cloud_call(cloud_call, "b"),
+    )
+
+    assert overlap_detected is False
+    assert order in [
+        ["start-a", "end-a", "start-b", "end-b"],
+        ["start-b", "end-b", "start-a", "end-a"],
+    ]

--- a/tests/test_write_updates_without_refresh.py
+++ b/tests/test_write_updates_without_refresh.py
@@ -9,6 +9,11 @@ from custom_components.webastoconnect.number import WebastoConnectNumber
 from custom_components.webastoconnect.switch import WebastoConnectSwitch
 
 
+async def _passthrough_cloud_call(func, *args):
+    """Execute cloud calls directly for write-path unit tests."""
+    return await func(*args)
+
+
 @pytest.mark.asyncio
 async def test_switch_turn_on_updates_listeners_without_refresh() -> None:
     """Switch turn_on should notify listeners and skip extra refresh."""
@@ -16,6 +21,7 @@ async def test_switch_turn_on_updates_listeners_without_refresh() -> None:
     coordinator = SimpleNamespace(
         async_update_listeners=Mock(),
         async_refresh=AsyncMock(),
+        async_execute_cloud_call=AsyncMock(side_effect=_passthrough_cloud_call),
     )
     switch = object.__new__(WebastoConnectSwitch)
     switch.entity_id = "switch.test"
@@ -27,6 +33,7 @@ async def test_switch_turn_on_updates_listeners_without_refresh() -> None:
     await switch.async_turn_on()
 
     command_fn.assert_awaited_once_with(switch._cloud, switch._cloud.devices[1], True)
+    coordinator.async_execute_cloud_call.assert_awaited_once()
     coordinator.async_update_listeners.assert_called_once()
     coordinator.async_refresh.assert_not_called()
 
@@ -38,6 +45,7 @@ async def test_switch_turn_off_updates_listeners_without_refresh() -> None:
     coordinator = SimpleNamespace(
         async_update_listeners=Mock(),
         async_refresh=AsyncMock(),
+        async_execute_cloud_call=AsyncMock(side_effect=_passthrough_cloud_call),
     )
     switch = object.__new__(WebastoConnectSwitch)
     switch.entity_id = "switch.test"
@@ -49,6 +57,7 @@ async def test_switch_turn_off_updates_listeners_without_refresh() -> None:
     await switch.async_turn_off()
 
     command_fn.assert_awaited_once_with(switch._cloud, switch._cloud.devices[1], False)
+    coordinator.async_execute_cloud_call.assert_awaited_once()
     coordinator.async_update_listeners.assert_called_once()
     coordinator.async_refresh.assert_not_called()
 
@@ -60,6 +69,7 @@ async def test_number_set_value_updates_listeners_without_refresh() -> None:
     coordinator = SimpleNamespace(
         async_update_listeners=Mock(),
         async_refresh=AsyncMock(),
+        async_execute_cloud_call=AsyncMock(side_effect=_passthrough_cloud_call),
     )
     number = object.__new__(WebastoConnectNumber)
     number.entity_id = "number.test"
@@ -71,6 +81,6 @@ async def test_number_set_value_updates_listeners_without_refresh() -> None:
     await number.async_set_native_value(12.5)
 
     set_fn.assert_awaited_once_with(number._cloud.devices[1], 12.5)
+    coordinator.async_execute_cloud_call.assert_awaited_once()
     coordinator.async_update_listeners.assert_called_once()
     coordinator.async_refresh.assert_not_called()
-


### PR DESCRIPTION
## Summary
- introduce a coordinator-level async lock and `async_execute_cloud_call` helper to serialize cloud operations
- route coordinator polling (`cloud.update`) and write commands (switch/number) through the same serialized execution path
- add race-focused unit coverage for serialized cloud calls and update existing write-path/coordinator tests

## Why
- improves robustness in concurrent poll + service-call scenarios where the backend active device context is mutable

## Test strategy
- `python3 -m pytest -q tests/test_api_coordinator.py tests/test_write_updates_without_refresh.py tests/test_coordinator_cloud_lock.py`

## Known limitations
- serialization is scoped per config entry/coordinator; multiple entries are still independent
- this change does not alter pywebasto internals, it enforces ordering at integration level

## Configuration changes
- none
