### PR TITLE
Enhance options updates with deterministic config-entry reload

### DIFF
--- a/custom_components/webastoconnect/__init__.py
+++ b/custom_components/webastoconnect/__init__.py
@@ -13,7 +13,14 @@ from homeassistant.util import slugify as util_slugify
 from pywebasto.exceptions import UnauthorizedException,InvalidRequestException
 
 from .api import WebastoConnectUpdateCoordinator
-from .const import ATTR_COORDINATOR, ATTR_DEVICES, DOMAIN, PLATFORMS, STARTUP
+from .const import (
+    ATTR_COORDINATOR,
+    ATTR_DEVICES,
+    ATTR_UPDATE_LISTENER,
+    DOMAIN,
+    PLATFORMS,
+    STARTUP,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +32,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     result = await _async_setup(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    hass.data[DOMAIN][entry.entry_id][ATTR_UPDATE_LISTENER] = (
+        entry.add_update_listener(async_reload_entry)
+    )
 
     return result
 
@@ -44,7 +54,7 @@ async def _async_migrate_unique_ids(
         entity_unique_id = entity_entry.unique_id
         entity_name = entity_entry.original_name
 
-        if not heater_name.lower() in str(entity_entry.suggested_object_id):
+        if heater_name.lower() not in str(entity_entry.suggested_object_id):
             LOGGER.debug(
                 "Skipping entity '%s' during migration, heater name '%s' not found in '%s'",
                 entity_entry.entity_id,
@@ -81,7 +91,7 @@ async def _async_migrate_unique_ids(
 
 
 async def _async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Setup the integration using a config entry."""
+    """Set up the integration using a config entry."""
     integration = await async_get_integration(hass, DOMAIN)
     LOGGER.info(
         STARTUP,
@@ -121,6 +131,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
+        update_listener = hass.data[DOMAIN][entry.entry_id].get(ATTR_UPDATE_LISTENER)
+        if callable(update_listener):
+            update_listener()
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
 

--- a/custom_components/webastoconnect/config_flow.py
+++ b/custom_components/webastoconnect/config_flow.py
@@ -7,11 +7,9 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
-from homeassistant.helpers.event import async_call_later
 from pywebasto import WebastoConnect
 from pywebasto.exceptions import UnauthorizedException
 
-from . import async_setup_entry, async_unload_entry
 from .const import DOMAIN
 
 LOGGER = logging.getLogger(__name__)
@@ -125,13 +123,6 @@ class WebastoConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class WebastoConnectOptionsFlow(config_entries.OptionsFlow):
     """Handle Webasto Connect options."""
 
-    async def _do_update(
-        self, *args, **kwargs  # pylint: disable=unused-argument
-    ) -> None:
-        """Update after settings change."""
-        await async_unload_entry(self.hass, self.config_entry)
-        await async_setup_entry(self.hass, self.config_entry)
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
@@ -150,7 +141,6 @@ class WebastoConnectOptionsFlow(config_entries.OptionsFlow):
                 errors["base"] = "invalid_auth"
 
             if "base" not in errors:
-                async_call_later(self.hass, 2, self._do_update)
                 return self.async_create_entry(
                     title=user_input[CONF_EMAIL], data=user_input
                 )

--- a/custom_components/webastoconnect/const.py
+++ b/custom_components/webastoconnect/const.py
@@ -19,3 +19,4 @@ NEW_DATA = "webasto_signal"
 
 ATTR_COORDINATOR = "updatecoordinator"
 ATTR_DEVICES = "devices"
+ATTR_UPDATE_LISTENER = "update_listener"

--- a/tests/test_options_reload_flow.py
+++ b/tests/test_options_reload_flow.py
@@ -1,0 +1,124 @@
+"""Tests for deterministic options reload behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from pywebasto.exceptions import UnauthorizedException
+
+import custom_components.webastoconnect as integration
+from custom_components.webastoconnect.config_flow import WebastoConnectOptionsFlow
+from custom_components.webastoconnect.const import ATTR_UPDATE_LISTENER, DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_update_listener(monkeypatch) -> None:
+    """Setup should register a config entry update listener."""
+    hass = SimpleNamespace(
+        data={},
+        config_entries=SimpleNamespace(async_forward_entry_setups=AsyncMock()),
+    )
+    remove_listener = Mock()
+    entry = SimpleNamespace(entry_id="entry-1", add_update_listener=Mock())
+    entry.add_update_listener.return_value = remove_listener
+
+    async def fake_setup(hass_obj, config_entry):
+        hass_obj.data.setdefault(DOMAIN, {})
+        hass_obj.data[DOMAIN][config_entry.entry_id] = {}
+        return True
+
+    monkeypatch.setattr(integration, "_async_setup", fake_setup)
+
+    result = await integration.async_setup_entry(hass, entry)
+
+    assert result is True
+    entry.add_update_listener.assert_called_once_with(integration.async_reload_entry)
+    assert hass.data[DOMAIN][entry.entry_id][ATTR_UPDATE_LISTENER] is remove_listener
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_calls_remove_listener_on_success() -> None:
+    """Unload should unsubscribe update listener before removing entry data."""
+    remove_listener = Mock()
+    entry = SimpleNamespace(entry_id="entry-1")
+    hass = SimpleNamespace(
+        data={DOMAIN: {"entry-1": {ATTR_UPDATE_LISTENER: remove_listener}}},
+        config_entries=SimpleNamespace(async_unload_platforms=AsyncMock(return_value=True)),
+    )
+
+    unload_ok = await integration.async_unload_entry(hass, entry)
+
+    assert unload_ok is True
+    remove_listener.assert_called_once()
+    assert "entry-1" not in hass.data[DOMAIN]
+
+
+@pytest.mark.asyncio
+async def test_options_flow_creates_entry_after_successful_auth(monkeypatch) -> None:
+    """Options flow should create entry directly after successful auth."""
+    connect_mock = AsyncMock()
+
+    class FakeWebasto:
+        """Minimal fake Webasto client for options flow tests."""
+
+        def __init__(self, *args, **kwargs) -> None:
+            """Initialize fake client."""
+
+        async def connect(self) -> None:
+            """Simulate successful auth."""
+            await connect_mock()
+
+    monkeypatch.setattr(
+        "custom_components.webastoconnect.config_flow.WebastoConnect",
+        FakeWebasto,
+    )
+
+    flow = object.__new__(WebastoConnectOptionsFlow)
+    config_entry = SimpleNamespace(data={}, options={})
+    flow.hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_get_known_entry=Mock(return_value=config_entry))
+    )
+    flow.handler = "entry-1"
+    flow.async_create_entry = Mock(return_value={"type": "create_entry"})
+
+    result = await flow.async_step_init({"email": "user@test", "password": "pw"})
+
+    connect_mock.assert_awaited_once()
+    flow.async_create_entry.assert_called_once_with(
+        title="user@test", data={"email": "user@test", "password": "pw"}
+    )
+    assert result == {"type": "create_entry"}
+
+
+@pytest.mark.asyncio
+async def test_options_flow_returns_error_on_invalid_auth(monkeypatch) -> None:
+    """Invalid auth should return form with invalid_auth error."""
+
+    class FakeWebasto:
+        """Fake client that always fails auth."""
+
+        def __init__(self, *args, **kwargs) -> None:
+            """Initialize fake client."""
+
+        async def connect(self) -> None:
+            """Simulate auth failure."""
+            raise UnauthorizedException("invalid")
+
+    monkeypatch.setattr(
+        "custom_components.webastoconnect.config_flow.WebastoConnect",
+        FakeWebasto,
+    )
+
+    flow = object.__new__(WebastoConnectOptionsFlow)
+    config_entry = SimpleNamespace(data={}, options={})
+    flow.hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_get_known_entry=Mock(return_value=config_entry))
+    )
+    flow.handler = "entry-1"
+    flow.async_show_form = Mock(return_value={"type": "form"})
+
+    result = await flow.async_step_init({"email": "user@test", "password": "bad"})
+
+    flow.async_show_form.assert_called_once()
+    assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "invalid_auth"}
+    assert result == {"type": "form"}


### PR DESCRIPTION
## Summary
- replace delayed options reload (`async_call_later`) with deterministic config-entry update listener handling
- register `entry.add_update_listener(async_reload_entry)` during setup and unsubscribe on unload
- add tests for listener registration, listener cleanup, and options-flow auth/error behavior

## Why
- removes timing uncertainty in options updates and aligns reload behavior with Home Assistant config-entry patterns

## Test strategy
- `python3 -m pytest -q tests/test_options_reload_flow.py tests/test_api_coordinator.py tests/test_write_updates_without_refresh.py tests/test_device_tracker_location.py`
- `ruff check custom_components/webastoconnect/__init__.py custom_components/webastoconnect/config_flow.py custom_components/webastoconnect/const.py tests/test_options_reload_flow.py`

## Known limitations
- reload remains entry-wide; option changes still restart all platforms for the entry

## Configuration changes
- none
