### PR TITLE
Reduce startup calls by skipping duplicate initial refresh

### DIFF
--- a/custom_components/webastoconnect/__init__.py
+++ b/custom_components/webastoconnect/__init__.py
@@ -6,11 +6,11 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed,ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.loader import async_get_integration
 from homeassistant.util import slugify as util_slugify
-from pywebasto.exceptions import UnauthorizedException,InvalidRequestException
+from pywebasto.exceptions import InvalidRequestException, UnauthorizedException
 
 from .api import WebastoConnectUpdateCoordinator
 from .const import (
@@ -115,7 +115,11 @@ async def _async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ATTR_DEVICES: {},
     }
 
-    await coordinator.async_config_entry_first_refresh()
+    if coordinator.cloud.devices:
+        # connect() already hydrated device state, avoid an immediate duplicate update call.
+        coordinator.async_set_updated_data(None)
+    else:
+        await coordinator.async_config_entry_first_refresh()
 
     for id, device in coordinator.cloud.devices.items():
         LOGGER.debug("Found device: %s", device.name)

--- a/tests/test_setup_initial_refresh.py
+++ b/tests/test_setup_initial_refresh.py
@@ -1,0 +1,77 @@
+"""Tests for setup bootstrap refresh behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from homeassistant.const import CONF_EMAIL
+
+import custom_components.webastoconnect as integration
+from custom_components.webastoconnect.const import ATTR_DEVICES, DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_setup_skips_first_refresh_when_connect_hydrates_devices(monkeypatch) -> None:
+    """Skip the coordinator first refresh if connect already provided devices."""
+    created: list[SimpleNamespace] = []
+    device = SimpleNamespace(name="Heater", device_id=1)
+
+    def coordinator_factory(*_args, **_kwargs):
+        coordinator = SimpleNamespace(
+            cloud=SimpleNamespace(connect=AsyncMock(), devices={1: device}),
+            async_config_entry_first_refresh=AsyncMock(),
+            async_set_updated_data=Mock(),
+        )
+        created.append(coordinator)
+        return coordinator
+
+    monkeypatch.setattr(integration, "WebastoConnectUpdateCoordinator", coordinator_factory)
+    monkeypatch.setattr(
+        integration,
+        "async_get_integration",
+        AsyncMock(return_value=SimpleNamespace(version="test")),
+    )
+    monkeypatch.setattr(integration, "_async_migrate_unique_ids", AsyncMock())
+
+    hass = SimpleNamespace(data={DOMAIN: {}})
+    entry = SimpleNamespace(entry_id="entry-1", data={CONF_EMAIL: "a@b.c"}, options={})
+
+    assert await integration._async_setup(hass, entry) is True
+
+    coordinator = created[0]
+    coordinator.cloud.connect.assert_awaited_once()
+    coordinator.async_set_updated_data.assert_called_once_with(None)
+    coordinator.async_config_entry_first_refresh.assert_not_awaited()
+    assert hass.data[DOMAIN]["entry-1"][ATTR_DEVICES][1] is device
+
+
+@pytest.mark.asyncio
+async def test_setup_runs_first_refresh_when_connect_has_no_devices(monkeypatch) -> None:
+    """Run the coordinator first refresh when connect did not hydrate devices."""
+    created: list[SimpleNamespace] = []
+
+    def coordinator_factory(*_args, **_kwargs):
+        coordinator = SimpleNamespace(
+            cloud=SimpleNamespace(connect=AsyncMock(), devices={}),
+            async_config_entry_first_refresh=AsyncMock(),
+            async_set_updated_data=Mock(),
+        )
+        created.append(coordinator)
+        return coordinator
+
+    monkeypatch.setattr(integration, "WebastoConnectUpdateCoordinator", coordinator_factory)
+    monkeypatch.setattr(
+        integration,
+        "async_get_integration",
+        AsyncMock(return_value=SimpleNamespace(version="test")),
+    )
+
+    hass = SimpleNamespace(data={DOMAIN: {}})
+    entry = SimpleNamespace(entry_id="entry-1", data={CONF_EMAIL: "a@b.c"}, options={})
+
+    assert await integration._async_setup(hass, entry) is True
+
+    coordinator = created[0]
+    coordinator.cloud.connect.assert_awaited_once()
+    coordinator.async_config_entry_first_refresh.assert_awaited_once()
+    coordinator.async_set_updated_data.assert_not_called()


### PR DESCRIPTION
## Summary
- avoid duplicate initial update call during setup when `coordinator.cloud.connect()` already hydrated device state
- use `coordinator.async_set_updated_data(None)` in that hydrated path
- keep fallback to `async_config_entry_first_refresh()` when connect did not populate devices
- add targeted tests for both bootstrap paths

## Why
- removes an unnecessary startup roundtrip and lowers API load while preserving setup reliability

## Test strategy
- `python3 -m pytest -q tests/test_setup_initial_refresh.py tests/test_options_reload_flow.py tests/test_api_coordinator.py tests/test_write_updates_without_refresh.py`
- `ruff check custom_components/webastoconnect/__init__.py tests/test_setup_initial_refresh.py`

## Known limitations
- behavior depends on current pywebasto contract where `connect()` performs an update

## Configuration changes
- none
