### PR TITLE
Enhance diagnostics payload with safer shape and raw API context

### DIFF
--- a/custom_components/webastoconnect/diagnostics.py
+++ b/custom_components/webastoconnect/diagnostics.py
@@ -15,6 +15,8 @@ from .const import ATTR_COORDINATOR, DOMAIN
 TO_REDACT = {
     CONF_PASSWORD,
     CONF_EMAIL,
+    "title",
+    "unique_id",
     CONF_LATITUDE,
     CONF_LONGITUDE,
     "lat",

--- a/tests/test_diagnostics_payload.py
+++ b/tests/test_diagnostics_payload.py
@@ -48,7 +48,9 @@ async def test_diagnostics_keeps_api_payload_and_redacts_sensitive_fields() -> N
     entry = SimpleNamespace(
         entry_id="entry-1",
         as_dict=lambda: {
-            "data": {"email": "user@example.com", "password": "secret"}
+            "title": "user@example.com",
+            "unique_id": "user@example.com",
+            "data": {"email": "user@example.com", "password": "secret"},
         },
     )
 
@@ -60,4 +62,6 @@ async def test_diagnostics_keeps_api_payload_and_redacts_sensitive_fields() -> N
     assert payload["api_payload"]["settings"]["general"]["acc_email"] == "**REDACTED**"
     assert diagnostics["entry"]["data"]["email"] == "**REDACTED**"
     assert diagnostics["entry"]["data"]["password"] == "**REDACTED**"
+    assert diagnostics["entry"]["title"] == "**REDACTED**"
+    assert diagnostics["entry"]["unique_id"] == "**REDACTED**"
     assert "_WebastoDevice__internal_only" not in payload


### PR DESCRIPTION
## Summary
- stop using full `device.__dict__` dumps in diagnostics
- keep bug-report value by explicitly including raw API payloads (`last_data`, `settings`, `dev_data`)
- retain useful high-level state fields for quick inspection
- keep redaction for sensitive fields (`email`, `password`, `lat`, `lon`, `acc_email`, etc.)
- add diagnostics test coverage for payload shape and redaction behavior

## Why
- preserves the original troubleshooting goal (full API response context)
- reduces exposure of private/internal object fields and avoids unnecessary payload bloat

## Test strategy
- `python3 -m pytest -q tests/test_diagnostics_payload.py tests/test_setup_initial_refresh.py tests/test_options_reload_flow.py`
- `ruff check custom_components/webastoconnect/diagnostics.py tests/test_diagnostics_payload.py`

## Known limitations
- payload can still be large when API responses are large; this change is conservative by design

## Configuration changes
- none
