### PR TITLE
Update AGENTS merge policy to prohibit admin override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,10 @@ Each PR must include:
 
 The agent must NOT merge a PR without explicit permission
 
+The agent must NOT use administrative merge overrides (for example `gh pr merge --admin`).
+
+Before merging any PR, the agent MUST wait until all required CI/status checks are green/passing.
+
 When a branch is merged it must also be deleted both local and remote, and changes merged to master must be pulled
 
 ---


### PR DESCRIPTION
## Summary
- add explicit rule that administrative merge overrides are not allowed
- require all required CI/status checks to be green before merging any PR

## Why
- aligns merge behavior with branch protection and quality gate expectations
- prevents bypassing required checks during merge

## Test strategy
- documentation/policy update only

## Configuration changes
- none
