### PR TITLE
Use ConfigEntry.runtime_data for integration runtime state

### DIFF
--- a/custom_components/webastoconnect/__init__.py
+++ b/custom_components/webastoconnect/__init__.py
@@ -1,7 +1,9 @@
 """Add Webasto ThermoConnect support to Home Assistant."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
 import logging
-from typing import Any
+from typing import Any, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL
@@ -13,30 +15,34 @@ from homeassistant.util import slugify as util_slugify
 from pywebasto.exceptions import InvalidRequestException, UnauthorizedException
 
 from .api import WebastoConnectUpdateCoordinator
-from .const import (
-    ATTR_COORDINATOR,
-    ATTR_DEVICES,
-    ATTR_UPDATE_LISTENER,
-    DOMAIN,
-    PLATFORMS,
-    STARTUP,
-)
+from .const import DOMAIN, PLATFORMS, STARTUP
 
 LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+@dataclass(slots=True)
+class WebastoRuntimeData:
+    """Runtime data for the Webasto config entry."""
+
+    coordinator: WebastoConnectUpdateCoordinator
+    update_listener: Callable[[], None]
+
+
+WebastoConfigEntry: TypeAlias = ConfigEntry[WebastoRuntimeData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> bool:
     """Set up cloud API connector from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-
-    result = await _async_setup(hass, entry)
-
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    hass.data[DOMAIN][entry.entry_id][ATTR_UPDATE_LISTENER] = (
-        entry.add_update_listener(async_reload_entry)
+    coordinator = await _async_setup(hass, entry)
+    update_listener = entry.add_update_listener(async_reload_entry)
+    entry.runtime_data = WebastoRuntimeData(
+        coordinator=coordinator,
+        update_listener=update_listener,
     )
 
-    return result
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
 
 
 async def _async_migrate_unique_ids(
@@ -90,7 +96,9 @@ async def _async_migrate_unique_ids(
     )
 
 
-async def _async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def _async_setup(
+    hass: HomeAssistant, entry: WebastoConfigEntry
+) -> WebastoConnectUpdateCoordinator:
     """Set up the integration using a config entry."""
     integration = await async_get_integration(hass, DOMAIN)
     LOGGER.info(
@@ -110,11 +118,6 @@ async def _async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except InvalidRequestException:
         raise ConfigEntryNotReady("Error connecting to the API - try again later")
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        ATTR_COORDINATOR: coordinator,
-        ATTR_DEVICES: {},
-    }
-
     if coordinator.cloud.devices:
         # connect() already hydrated device state, avoid an immediate duplicate update call.
         coordinator.async_set_updated_data(None)
@@ -125,24 +128,20 @@ async def _async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         LOGGER.debug("Found device: %s", device.name)
         # Migrate unique IDs
         await _async_migrate_unique_ids(hass, id, device.name, entry)
-        hass.data[DOMAIN][entry.entry_id][ATTR_DEVICES][id] = device
 
-    return True
+    return coordinator
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        update_listener = hass.data[DOMAIN][entry.entry_id].get(ATTR_UPDATE_LISTENER)
-        if callable(update_listener):
-            update_listener()
-        hass.data[DOMAIN].pop(entry.entry_id)
+        entry.runtime_data.update_listener()
     return unload_ok
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_reload_entry(hass: HomeAssistant, entry: WebastoConfigEntry) -> None:
     """Reload config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)

--- a/custom_components/webastoconnect/binary_sensor.py
+++ b/custom_components/webastoconnect/binary_sensor.py
@@ -5,14 +5,13 @@ from typing import cast
 
 from homeassistant.components import binary_sensor
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.util import slugify as util_slugify
 
+from . import WebastoConfigEntry
 from .api import WebastoConnectUpdateCoordinator
 from .base import WebastoBaseEntity, WebastoConnectBinarySensorEntityDescription
-from .const import ATTR_COORDINATOR, DOMAIN
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,11 +28,11 @@ BINARY_SENSORS = [
 ]
 
 
-async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):
+async def async_setup_entry(hass, entry: WebastoConfigEntry, async_add_devices):
     """Set up binary sensors."""
     binarysensors = []
 
-    coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
+    coordinator = entry.runtime_data.coordinator
 
     for id, device in coordinator.cloud.devices.items():
         LOGGER.debug("Setting up binary_sensors for device: %s", device.name)

--- a/custom_components/webastoconnect/const.py
+++ b/custom_components/webastoconnect/const.py
@@ -16,7 +16,3 @@ DOMAIN = "webastoconnect"
 
 PLATFORMS = ["sensor", "switch", "device_tracker", "binary_sensor", "number"]
 NEW_DATA = "webasto_signal"
-
-ATTR_COORDINATOR = "updatecoordinator"
-ATTR_DEVICES = "devices"
-ATTR_UPDATE_LISTENER = "update_listener"

--- a/custom_components/webastoconnect/device_tracker.py
+++ b/custom_components/webastoconnect/device_tracker.py
@@ -5,15 +5,14 @@ import logging
 from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker.const import SourceType
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.util import slugify as util_slugify
 
+from . import WebastoConfigEntry
 from custom_components.webastoconnect.base import WebastoBaseEntity
 
 from .api import WebastoConnectUpdateCoordinator
-from .const import ATTR_COORDINATOR, DOMAIN
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,9 +24,9 @@ TRACKER = EntityDescription(
 )
 
 
-async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):
+async def async_setup_entry(hass, entry: WebastoConfigEntry, async_add_devices):
     """Set up device tracker."""
-    coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
+    coordinator = entry.runtime_data.coordinator
     trackers = []
 
     for id, device in coordinator.cloud.devices.items():

--- a/custom_components/webastoconnect/diagnostics.py
+++ b/custom_components/webastoconnect/diagnostics.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_LATITUDE, CONF_LONGITUDE, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
+from . import WebastoConfigEntry
 from .api import WebastoConnectUpdateCoordinator
-from .const import ATTR_COORDINATOR, DOMAIN
 
 TO_REDACT = {
     CONF_PASSWORD,
@@ -27,7 +26,7 @@ TO_REDACT = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: WebastoConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     data_dict = {
@@ -35,9 +34,7 @@ async def async_get_config_entry_diagnostics(
         "devices": {},
     }
 
-    api: WebastoConnectUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
-        ATTR_COORDINATOR
-    ]
+    api: WebastoConnectUpdateCoordinator = entry.runtime_data.coordinator
 
     for id, device in api.cloud.devices.items():
         data_dict["devices"][str(id)] = {

--- a/custom_components/webastoconnect/number.py
+++ b/custom_components/webastoconnect/number.py
@@ -5,13 +5,12 @@ from typing import cast
 
 from homeassistant.components import number
 from homeassistant.components.number import NumberEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.util import slugify as util_slugify
 
+from . import WebastoConfigEntry
 from .api import WebastoConnectUpdateCoordinator
 from .base import WebastoBaseEntity, WebastoConnectNumberEntityDescription
-from .const import ATTR_COORDINATOR, DOMAIN
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,11 +44,11 @@ NUMBERS = [
 ]
 
 
-async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):
+async def async_setup_entry(hass, entry: WebastoConfigEntry, async_add_devices):
     """Set up numbers."""
     numbers_list = []
 
-    coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
+    coordinator = entry.runtime_data.coordinator
 
     for id, device in coordinator.cloud.devices.items():
         LOGGER.debug("Setting up numbers for device: %s", device.name)

--- a/custom_components/webastoconnect/sensor.py
+++ b/custom_components/webastoconnect/sensor.py
@@ -8,14 +8,13 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.util import slugify as util_slugify
 
+from . import WebastoConfigEntry
 from .api import WebastoConnectUpdateCoordinator
 from .base import WebastoBaseEntity, WebastoConnectSensorEntityDescription
-from .const import ATTR_COORDINATOR, DOMAIN
 
 LOGGER = logging.getLogger(__name__)
 
@@ -55,11 +54,11 @@ SENSORS = [
 ]
 
 
-async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):
+async def async_setup_entry(hass, entry: WebastoConfigEntry, async_add_devices):
     """Set up sensors."""
     sensors = []
 
-    coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
+    coordinator = entry.runtime_data.coordinator
 
     for id, device in coordinator.cloud.devices.items():
         LOGGER.debug("Setting up sensors for device: %s", device.name)

--- a/custom_components/webastoconnect/switch.py
+++ b/custom_components/webastoconnect/switch.py
@@ -5,14 +5,13 @@ from typing import Any, cast
 
 from homeassistant.components import switch
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import callback
 from homeassistant.util import slugify as util_slugify
 
+from . import WebastoConfigEntry
 from .api import WebastoConnectUpdateCoordinator
 from .base import WebastoBaseEntity, WebastoConnectSwitchEntityDescription
-from .const import ATTR_COORDINATOR, DOMAIN
 
 LOGGER = logging.getLogger(__name__)
 
@@ -55,11 +54,11 @@ SWITCHES = [
 ]
 
 
-async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):
+async def async_setup_entry(hass, entry: WebastoConfigEntry, async_add_devices):
     """Set up switches."""
     switches = []
 
-    coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
+    coordinator = entry.runtime_data.coordinator
 
     for id, device in coordinator.cloud.devices.items():
         LOGGER.debug("Setting up switches for device: %s", device.name)

--- a/tests/test_diagnostics_payload.py
+++ b/tests/test_diagnostics_payload.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from custom_components.webastoconnect.const import ATTR_COORDINATOR, DOMAIN
 from custom_components.webastoconnect.diagnostics import (
     async_get_config_entry_diagnostics,
 )
@@ -34,19 +33,12 @@ async def test_diagnostics_keeps_api_payload_and_redacts_sensitive_fields() -> N
         _WebastoDevice__internal_only="should_not_be_exposed",
     )
 
-    hass = SimpleNamespace(
-        data={
-            DOMAIN: {
-                "entry-1": {
-                    ATTR_COORDINATOR: SimpleNamespace(
-                        cloud=SimpleNamespace(devices={123: device})
-                    )
-                }
-            }
-        }
-    )
+    hass = SimpleNamespace()
     entry = SimpleNamespace(
         entry_id="entry-1",
+        runtime_data=SimpleNamespace(
+            coordinator=SimpleNamespace(cloud=SimpleNamespace(devices={123: device}))
+        ),
         as_dict=lambda: {
             "title": "user@example.com",
             "unique_id": "user@example.com",

--- a/tests/test_options_reload_flow.py
+++ b/tests/test_options_reload_flow.py
@@ -8,7 +8,6 @@ from pywebasto.exceptions import UnauthorizedException
 
 import custom_components.webastoconnect as integration
 from custom_components.webastoconnect.config_flow import WebastoConnectOptionsFlow
-from custom_components.webastoconnect.const import ATTR_UPDATE_LISTENER, DOMAIN
 
 
 @pytest.mark.asyncio
@@ -21,11 +20,10 @@ async def test_async_setup_entry_registers_update_listener(monkeypatch) -> None:
     remove_listener = Mock()
     entry = SimpleNamespace(entry_id="entry-1", add_update_listener=Mock())
     entry.add_update_listener.return_value = remove_listener
+    coordinator = SimpleNamespace()
 
     async def fake_setup(hass_obj, config_entry):
-        hass_obj.data.setdefault(DOMAIN, {})
-        hass_obj.data[DOMAIN][config_entry.entry_id] = {}
-        return True
+        return coordinator
 
     monkeypatch.setattr(integration, "_async_setup", fake_setup)
 
@@ -33,16 +31,19 @@ async def test_async_setup_entry_registers_update_listener(monkeypatch) -> None:
 
     assert result is True
     entry.add_update_listener.assert_called_once_with(integration.async_reload_entry)
-    assert hass.data[DOMAIN][entry.entry_id][ATTR_UPDATE_LISTENER] is remove_listener
+    assert entry.runtime_data.coordinator is coordinator
+    assert entry.runtime_data.update_listener is remove_listener
 
 
 @pytest.mark.asyncio
 async def test_async_unload_entry_calls_remove_listener_on_success() -> None:
     """Unload should unsubscribe update listener before removing entry data."""
     remove_listener = Mock()
-    entry = SimpleNamespace(entry_id="entry-1")
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        runtime_data=SimpleNamespace(update_listener=remove_listener),
+    )
     hass = SimpleNamespace(
-        data={DOMAIN: {"entry-1": {ATTR_UPDATE_LISTENER: remove_listener}}},
         config_entries=SimpleNamespace(async_unload_platforms=AsyncMock(return_value=True)),
     )
 
@@ -50,7 +51,6 @@ async def test_async_unload_entry_calls_remove_listener_on_success() -> None:
 
     assert unload_ok is True
     remove_listener.assert_called_once()
-    assert "entry-1" not in hass.data[DOMAIN]
 
 
 @pytest.mark.asyncio

--- a/tests/test_setup_initial_refresh.py
+++ b/tests/test_setup_initial_refresh.py
@@ -7,7 +7,6 @@ import pytest
 from homeassistant.const import CONF_EMAIL
 
 import custom_components.webastoconnect as integration
-from custom_components.webastoconnect.const import ATTR_DEVICES, DOMAIN
 
 
 @pytest.mark.asyncio
@@ -25,24 +24,28 @@ async def test_setup_skips_first_refresh_when_connect_hydrates_devices(monkeypat
         created.append(coordinator)
         return coordinator
 
-    monkeypatch.setattr(integration, "WebastoConnectUpdateCoordinator", coordinator_factory)
+    monkeypatch.setattr(
+        integration, "WebastoConnectUpdateCoordinator", coordinator_factory
+    )
     monkeypatch.setattr(
         integration,
         "async_get_integration",
         AsyncMock(return_value=SimpleNamespace(version="test")),
     )
-    monkeypatch.setattr(integration, "_async_migrate_unique_ids", AsyncMock())
+    migrate_mock = AsyncMock()
+    monkeypatch.setattr(integration, "_async_migrate_unique_ids", migrate_mock)
 
-    hass = SimpleNamespace(data={DOMAIN: {}})
+    hass = SimpleNamespace()
     entry = SimpleNamespace(entry_id="entry-1", data={CONF_EMAIL: "a@b.c"}, options={})
 
-    assert await integration._async_setup(hass, entry) is True
+    result = await integration._async_setup(hass, entry)
 
     coordinator = created[0]
+    assert result is coordinator
     coordinator.cloud.connect.assert_awaited_once()
     coordinator.async_set_updated_data.assert_called_once_with(None)
     coordinator.async_config_entry_first_refresh.assert_not_awaited()
-    assert hass.data[DOMAIN]["entry-1"][ATTR_DEVICES][1] is device
+    migrate_mock.assert_awaited_once_with(hass, 1, "Heater", entry)
 
 
 @pytest.mark.asyncio
@@ -59,19 +62,22 @@ async def test_setup_runs_first_refresh_when_connect_has_no_devices(monkeypatch)
         created.append(coordinator)
         return coordinator
 
-    monkeypatch.setattr(integration, "WebastoConnectUpdateCoordinator", coordinator_factory)
+    monkeypatch.setattr(
+        integration, "WebastoConnectUpdateCoordinator", coordinator_factory
+    )
     monkeypatch.setattr(
         integration,
         "async_get_integration",
         AsyncMock(return_value=SimpleNamespace(version="test")),
     )
 
-    hass = SimpleNamespace(data={DOMAIN: {}})
+    hass = SimpleNamespace()
     entry = SimpleNamespace(entry_id="entry-1", data={CONF_EMAIL: "a@b.c"}, options={})
 
-    assert await integration._async_setup(hass, entry) is True
+    result = await integration._async_setup(hass, entry)
 
     coordinator = created[0]
+    assert result is coordinator
     coordinator.cloud.connect.assert_awaited_once()
     coordinator.async_config_entry_first_refresh.assert_awaited_once()
     coordinator.async_set_updated_data.assert_not_called()


### PR DESCRIPTION
## Summary
- migrate integration runtime storage from `hass.data[DOMAIN][entry_id]` to typed `ConfigEntry.runtime_data`
- add `WebastoRuntimeData` and `WebastoConfigEntry` typing in `__init__.py`
- update setup/unload/reload lifecycle to use `entry.runtime_data`
- update all platforms and diagnostics to read coordinator from `entry.runtime_data.coordinator`
- remove now-obsolete coordinator/devices/update-listener constants
- update affected unit tests for the new runtime-data model

## Why
- aligns integration with current Home Assistant guidance for storing runtime data
- improves type safety and avoids ad-hoc global storage in `hass.data`

## Test strategy
- `ruff check custom_components/webastoconnect tests`
- `python3 -m pytest -q tests`

## Configuration changes
- none
