### PR TITLE
Ignore local_notes from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 .coverage
 coverage.xml
 notes.txt
+local_notes/
 
 
 # Home Assistant configuration


### PR DESCRIPTION
## Summary
- add `local_notes/` to `.gitignore`

## Why
- diagnostics dumps and local analysis files should stay local and not be committed

## Test strategy
- not applicable (gitignore-only)
