### PR TITLE
ci: fix release PR creation on detached HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
           add-paths: ./custom_components/webastoconnect/manifest.json
           commit-message: "release: update manifest for ${{ github.event.release.tag_name }}"
           branch: "chore/release-manifest-${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Summary
- set `base: main` for the release manifest PR step

## Why
Release runs from a tag checkout (detached HEAD). `peter-evans/create-pull-request` requires `base` in this mode.

## Test strategy
- verify release workflow creates manifest PR instead of failing on detached HEAD.
