### PR TITLE
ci: make release merge manifest PR without auto-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,7 @@ jobs:
       - name: Verify gh is available
         run: |
           gh --version
-      - name: Enable auto-merge for manifest PR
-        if: ${{ steps.create_manifest_pr.outputs.pull-request-number != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr merge "${{ steps.create_manifest_pr.outputs.pull-request-number }}" --auto --squash --delete-branch
-      - name: Wait for manifest PR merge
+      - name: Wait for manifest PR checks and merge
         id: wait_manifest_pr_merge
         if: ${{ steps.create_manifest_pr.outputs.pull-request-number != '' }}
         env:
@@ -53,28 +47,20 @@ jobs:
         run: |
           set -euo pipefail
           pr_number="${{ steps.create_manifest_pr.outputs.pull-request-number }}"
-          max_attempts=120
+          max_attempts=80
           sleep_seconds=15
 
           for attempt in $(seq 1 "$max_attempts"); do
-            merged_at="$(gh pr view "$pr_number" --json mergedAt -q '.mergedAt')"
-            state="$(gh pr view "$pr_number" --json state -q '.state')"
-
-            if [ "$merged_at" != "null" ] && [ -n "$merged_at" ]; then
+            if gh pr checks "$pr_number" --required; then
+              gh pr merge "$pr_number" --squash --delete-branch
               merge_sha="$(gh pr view "$pr_number" --json mergeCommit -q '.mergeCommit.oid')"
               echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-
-            if [ "$state" = "CLOSED" ]; then
-              echo "Manifest PR #$pr_number was closed without merge."
-              exit 1
-            fi
-
             sleep "$sleep_seconds"
           done
 
-          echo "Timed out waiting for manifest PR #$pr_number to merge."
+          echo "Timed out waiting for required checks on manifest PR #$pr_number."
           exit 1
       - name: Checkout merged commit
         if: ${{ steps.wait_manifest_pr_merge.outputs.merge_sha != '' }}


### PR DESCRIPTION
## Summary
- remove dependency on repository auto-merge setting
- wait for required checks on the manifest PR
- merge the PR directly once checks pass
- continue release flow from merged commit

## Source of truth used
- release run 22619276426 failed with: "Pull request Auto merge is not allowed for this repository"
- current main branch protection requires 3 checks:
  - HACS validation
  - Hassfest validation
  - Lint + Tests (Python 3.14)

## Test strategy
- publish a new test release tag and verify release workflow:
  1. creates manifest PR with skip-changelog
  2. waits for required checks
  3. merges PR
  4. builds and uploads zip
