### PR TITLE
chore: ignore node_modules artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ local_notes/
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+
+# node modules
+node_modules/


### PR DESCRIPTION
Adds node_modules/ to .gitignore so local npm installs (including card-src/node_modules) no longer appear as untracked files on main.
