### PR TITLE
ci: use PAT so release manifest PR checks start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,14 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+      - name: Validate release automation token
+        env:
+          RELEASE_WORKFLOW_TOKEN: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_WORKFLOW_TOKEN" ]; then
+            echo "::error::Missing secret RELEASE_WORKFLOW_TOKEN. Configure a PAT (repo scope) so required checks can run on the manifest PR."
+            exit 1
+          fi
       - name: Update manifest.json version to ${{ github.event.release.tag_name }}
         run: |
           python3 ${{ github.workspace }}/.github/scripts/update_hacs_manifest.py --version ${{ github.event.release.tag_name }} --path /custom_components/webastoconnect/
@@ -26,7 +34,8 @@ jobs:
         id: create_manifest_pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
+          branch-token: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
           base: main
           add-paths: ./custom_components/webastoconnect/manifest.json
           commit-message: "release: update manifest for ${{ github.event.release.tag_name }}"
@@ -43,7 +52,7 @@ jobs:
         id: wait_manifest_pr_merge
         if: ${{ steps.create_manifest_pr.outputs.pull-request-number != '' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
         run: |
           set -euo pipefail
           pr_number="${{ steps.create_manifest_pr.outputs.pull-request-number }}"


### PR DESCRIPTION
## Summary
- use `RELEASE_WORKFLOW_TOKEN` for release manifest PR creation and merge
- add explicit fail-fast step when token is missing

## Why
Current release-created manifest PRs are authored by `github-actions` and do not trigger required workflows, leaving checks stuck at "Expected — Waiting for status to be reported".

## Behavior after change
- if `RELEASE_WORKFLOW_TOKEN` is configured, required checks run on the manifest PR and release can continue
- if not configured, release fails immediately with a clear error
