### PR TITLE
Guard reauth behind credential re-validation

### DIFF
--- a/custom_components/webastoconnect/api.py
+++ b/custom_components/webastoconnect/api.py
@@ -76,7 +76,30 @@ class WebastoConnectUpdateCoordinator(DataUpdateCoordinator[None]):
         except UnauthorizedException as err:
             self._consecutive_unauthorized += 1
             if self._consecutive_unauthorized >= MAX_CONSECUTIVE_UNAUTHORIZED:
-                raise ConfigEntryAuthFailed("Authentication with Webasto failed") from err
+                LOGGER.warning(
+                    "Received %s consecutive unauthorized responses, validating credentials before reauth",
+                    self._consecutive_unauthorized,
+                )
+                try:
+                    await self.async_execute_cloud_call(self.cloud.connect)
+                except UnauthorizedException as verify_err:
+                    raise ConfigEntryAuthFailed(
+                        "Authentication with Webasto failed"
+                    ) from verify_err
+                except InvalidRequestException as verify_err:
+                    self._consecutive_unauthorized = 0
+                    raise UpdateFailed(
+                        f"Unable to verify authentication state: {verify_err}"
+                    ) from verify_err
+                except Exception as verify_err:
+                    self._consecutive_unauthorized = 0
+                    raise UpdateFailed(
+                        f"Temporary failure while verifying authentication state: {verify_err}",
+                        retry_after=300,
+                    ) from verify_err
+
+                self._consecutive_unauthorized = 0
+                return None
 
             raise UpdateFailed(
                 "Received unauthorized from Webasto API, retrying shortly",

--- a/tests/test_api_coordinator.py
+++ b/tests/test_api_coordinator.py
@@ -19,7 +19,7 @@ from custom_components.webastoconnect.api import (
 def _build_coordinator(update_mock: AsyncMock) -> WebastoConnectUpdateCoordinator:
     """Create a minimal coordinator instance for unit testing."""
     coordinator = object.__new__(WebastoConnectUpdateCoordinator)
-    coordinator.cloud = SimpleNamespace(update=update_mock)
+    coordinator.cloud = SimpleNamespace(update=update_mock, connect=AsyncMock())
     coordinator._consecutive_unauthorized = 0
     coordinator._cloud_operation_lock = asyncio.Lock()
     return coordinator
@@ -55,6 +55,9 @@ async def test_update_data_raises_auth_failed_after_consecutive_unauthorized() -
     """Repeated unauthorized responses should trigger reauth."""
     update_mock = AsyncMock(side_effect=UnauthorizedException("invalid auth"))
     coordinator = _build_coordinator(update_mock)
+    coordinator.cloud.connect = AsyncMock(
+        side_effect=UnauthorizedException("invalid auth")
+    )
 
     for _ in range(MAX_CONSECUTIVE_UNAUTHORIZED - 1):
         with pytest.raises(UpdateFailed):
@@ -62,6 +65,40 @@ async def test_update_data_raises_auth_failed_after_consecutive_unauthorized() -
 
     with pytest.raises(ConfigEntryAuthFailed):
         await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_update_data_does_not_reauth_when_validation_succeeds() -> None:
+    """Credential re-validation success should avoid triggering reauth."""
+    update_mock = AsyncMock(side_effect=UnauthorizedException("transient unauthorized"))
+    coordinator = _build_coordinator(update_mock)
+
+    for _ in range(MAX_CONSECUTIVE_UNAUTHORIZED - 1):
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    await coordinator._async_update_data()
+
+    coordinator.cloud.connect.assert_awaited_once()
+    assert coordinator._consecutive_unauthorized == 0
+
+
+@pytest.mark.asyncio
+async def test_update_data_reauth_validation_network_failure_is_transient() -> None:
+    """Unexpected errors during auth validation should not trigger reauth."""
+    update_mock = AsyncMock(side_effect=UnauthorizedException("transient unauthorized"))
+    coordinator = _build_coordinator(update_mock)
+    coordinator.cloud.connect = AsyncMock(side_effect=RuntimeError("network down"))
+
+    for _ in range(MAX_CONSECUTIVE_UNAUTHORIZED - 1):
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    with pytest.raises(UpdateFailed) as exc_info:
+        await coordinator._async_update_data()
+
+    assert exc_info.value.retry_after == 300
+    assert coordinator._consecutive_unauthorized == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- change coordinator unauthorized handling to verify auth state with `cloud.connect()` before raising `ConfigEntryAuthFailed`
- keep transient failures (`InvalidRequestException` / unexpected exceptions) as `UpdateFailed` during verification
- add coordinator unit tests covering verified reauth, successful verification, and transient verification failure

## Test strategy
- `.venv/bin/pytest -q tests/test_api_coordinator.py`
- `.venv/bin/ruff check custom_components/webastoconnect/api.py tests/test_api_coordinator.py`

## Known limitations
- if Webasto backend returns persistent `UnauthorizedException` for non-auth reasons, reauth may still trigger after verification because the backend signal is indistinguishable

## Required configuration changes
- none
