### PR TITLE
Add pywebasto module rewrite support

### DIFF
--- a/custom_components/webastoconnect/__init__.py
+++ b/custom_components/webastoconnect/__init__.py
@@ -14,10 +14,17 @@ from homeassistant.components.lovelace.const import (
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_EMAIL, CONF_TYPE, CONF_URL
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.loader import async_get_integration
 from homeassistant.util import slugify as util_slugify
+from pywebasto.enums import Request
 from pywebasto.exceptions import InvalidRequestException, UnauthorizedException
 
 try:
@@ -32,11 +39,13 @@ except ImportError:
     TooManyRequestsException = InvalidRequestException
 
 from .api import WebastoConnectUpdateCoordinator
+from .base import webasto_device_name
 from .card_install import ensure_card_installed
 from .const import CARD_FILENAME, CARD_WWW_SUBDIR, DOMAIN, PLATFORMS, STARTUP
 from .services import async_register_services, async_unregister_services
 
 LOGGER = logging.getLogger(__name__)
+PENDING_APPROVAL_ISSUE_ID = "pending_approval"
 
 
 @dataclass(slots=True)
@@ -116,6 +125,66 @@ async def _async_migrate_unique_ids(
     )
 
 
+async def _async_update_device_registry_name(
+    hass: HomeAssistant,
+    device_id: int,
+    device_name: str,
+) -> None:
+    """Update the device registry name."""
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device({(DOMAIN, str(device_id))})
+    if device_entry is None or device_entry.name_by_user is not None:
+        return
+    if device_entry.name == device_name:
+        return
+
+    device_registry.async_update_device(device_entry.id, name=device_name)
+
+
+def _device_names_from_webapi_data(data: dict[str, Any]) -> dict[str, str]:
+    """Return device names from webapi data."""
+    names = {}
+    if data.get("id") and data.get("alias"):
+        names[str(data["id"])] = str(data["alias"])
+
+    for device in data.get("account_info", {}).get("devices", []):
+        if isinstance(device, dict):
+            device_id = (
+                device.get("id") or device.get("device_id") or device.get("dev_id")
+            )
+            device_name = device.get("name") or device.get("alias")
+        else:
+            device_id = device[0] if len(device) > 0 else None
+            device_name = device[1] if len(device) > 1 else None
+        if device_id and device_name:
+            names[str(device_id)] = str(device_name)
+
+    return names
+
+
+async def _async_webapi_device_names(
+    coordinator: WebastoConnectUpdateCoordinator,
+) -> dict[str, str]:
+    """Fetch device names from webapi when available."""
+    if not coordinator.cloud.uses_webapi_session:
+        return {}
+
+    try:
+        data = await coordinator.cloud._call(Request.GET_DATA_NOPOLL)  # noqa: SLF001
+    except (
+        InvalidRequestException,
+        ForbiddenException,
+        InvalidResponseException,
+    ) as err:
+        LOGGER.debug("Could not fetch Webasto webapi device names: %s", err)
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    return _device_names_from_webapi_data(data)
+
+
 async def _async_setup(
     hass: HomeAssistant, entry: WebastoConfigEntry
 ) -> WebastoConnectUpdateCoordinator:
@@ -152,7 +221,7 @@ async def _async_setup(
         )
     await _async_ensure_lovelace_card_resource(hass, card_hash)
 
-    coordinator = WebastoConnectUpdateCoordinator(hass, entry)
+    coordinator = WebastoConnectUpdateCoordinator(hass, entry, integration.version)
     try:
         await coordinator.cloud.connect()
         LOGGER.debug(
@@ -162,12 +231,53 @@ async def _async_setup(
     except UnauthorizedException:
         await coordinator.cloud.close()
         raise ConfigEntryAuthFailed("Invalid email or password specified") from None
-    except (InvalidRequestException, ForbiddenException, InvalidResponseException):
+    except (InvalidRequestException, ForbiddenException) as err:
         await coordinator.cloud.close()
-        raise ConfigEntryNotReady("Error connecting to the API - try again later")
-    except TooManyRequestsException:
+        raise ConfigEntryError(f"Webasto API rejected setup request: {err}") from err
+    except InvalidResponseException as err:
         await coordinator.cloud.close()
-        raise ConfigEntryNotReady("Rate limited - try again later")
+        raise ConfigEntryNotReady(
+            f"Error connecting to the API - try again later: {err}"
+        ) from err
+    except TooManyRequestsException as err:
+        await coordinator.cloud.close()
+        raise ConfigEntryError(
+            f"Rate limited - reload the integration later: {err}"
+        ) from err
+
+    webapi_device_names = await _async_webapi_device_names(coordinator)
+    coordinator.device_names = webapi_device_names
+
+    pending_devices = [
+        device
+        for device in coordinator.cloud.devices.values()
+        if getattr(device, "pending_approval", False)
+    ]
+    if pending_devices:
+        devices = ", ".join(
+            webasto_device_name(
+                device,
+                webapi_device_names.get(str(device.device_id)),
+            )
+            for device in pending_devices
+        )
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            PENDING_APPROVAL_ISSUE_ID,
+            data={"entry_id": entry.entry_id},
+            is_fixable=True,
+            is_persistent=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="pending_approval",
+            translation_placeholders={"devices": devices},
+        )
+        await coordinator.cloud.close()
+        raise ConfigEntryError(
+            "Webasto device association is pending approval in the ThermoConnect app"
+        )
+
+    ir.async_delete_issue(hass, DOMAIN, PENDING_APPROVAL_ISSUE_ID)
 
     if coordinator.cloud.devices:
         # connect() already hydrated device state, avoid an immediate duplicate update call.
@@ -176,9 +286,11 @@ async def _async_setup(
         await coordinator.async_config_entry_first_refresh()
 
     for id, device in coordinator.cloud.devices.items():
-        LOGGER.debug("Found device: %s", device.name)
+        device_name = webasto_device_name(device, webapi_device_names.get(str(id)))
+        LOGGER.debug("Found device: %s", device_name)
+        await _async_update_device_registry_name(hass, id, device_name)
         # Migrate unique IDs
-        await _async_migrate_unique_ids(hass, id, device.name, entry)
+        await _async_migrate_unique_ids(hass, id, device_name, entry)
 
     return coordinator
 

--- a/custom_components/webastoconnect/api.py
+++ b/custom_components/webastoconnect/api.py
@@ -1,10 +1,12 @@
 """API connector class."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
+import json
 import logging
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, TypeVar
-from collections.abc import Awaitable, Callable
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -27,27 +29,63 @@ except ImportError:
 
 from .const import DOMAIN
 
-SCAN_INTERVAL = timedelta(seconds=30)
+SCAN_INTERVAL = timedelta(seconds=60)
 LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-class WebastoConnector:
-    """Webasto Connector."""
+def _credential_store_path(hass: HomeAssistant, entry: ConfigEntry) -> str:
+    """Return the pywebasto app credential store path for a config entry."""
+    return hass.config.path(".storage", f"webasto_{entry.entry_id}.json")
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize the connector."""
-        self.hass = hass
-        self.cloud: WebastoConnect = WebastoConnect(
-            entry.options.get(CONF_EMAIL, entry.data.get(CONF_EMAIL)),
-            entry.options.get(CONF_PASSWORD, entry.data.get(CONF_PASSWORD)),
+
+def _load_credentials(path: Path) -> dict[str, str] | None:
+    """Load pywebasto app credentials."""
+    if not path.exists():
+        return None
+
+    with path.open(encoding="utf-8") as credential_file:
+        return json.load(credential_file)
+
+
+def _save_credentials(path: Path, credentials: Any) -> None:
+    """Save pywebasto app credentials."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as credential_file:
+        json.dump(
+            {
+                "client_id": credentials.client_id,
+                "client_secret": credentials.client_secret,
+            },
+            credential_file,
+            indent=2,
         )
+        credential_file.write("\n")
+
+
+def _credential_callbacks(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> tuple[
+    Callable[[], Awaitable[dict[str, str] | None]], Callable[[Any], Awaitable[None]]
+]:
+    """Return pywebasto credential callbacks."""
+    path = Path(_credential_store_path(hass, entry))
+
+    async def credential_load() -> dict[str, str] | None:
+        return await hass.async_add_executor_job(_load_credentials, path)
+
+    async def credential_save(credentials: Any) -> None:
+        await hass.async_add_executor_job(_save_credentials, path, credentials)
+
+    return credential_load, credential_save
 
 
 class WebastoConnectUpdateCoordinator(DataUpdateCoordinator[None]):
     """webasto Connect data update coordinator."""
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(
+        self, hass: HomeAssistant, entry: ConfigEntry, version: str = "unknown"
+    ) -> None:
         """Initialize the connection."""
         DataUpdateCoordinator.__init__(
             self,
@@ -59,11 +97,16 @@ class WebastoConnectUpdateCoordinator(DataUpdateCoordinator[None]):
 
         self.hass = hass
         self.config_entry = entry
+        credential_load, credential_save = _credential_callbacks(hass, entry)
         self.cloud: WebastoConnect = WebastoConnect(
-            entry.options.get(CONF_EMAIL, entry.data.get(CONF_EMAIL)),
-            entry.options.get(CONF_PASSWORD, entry.data.get(CONF_PASSWORD)),
+            username=entry.options.get(CONF_EMAIL, entry.data.get(CONF_EMAIL)),
+            password=entry.options.get(CONF_PASSWORD, entry.data.get(CONF_PASSWORD)),
+            credential_load=credential_load,
+            credential_save=credential_save,
+            client_info=f"HomeAssistant-Webasto {version} {int(datetime.now().timestamp())}",
         )
         self._cloud_operation_lock = asyncio.Lock()
+        self.device_names: dict[str, str] = {}
 
     async def async_execute_cloud_call(
         self,

--- a/custom_components/webastoconnect/base.py
+++ b/custom_components/webastoconnect/base.py
@@ -20,6 +20,20 @@ from .api import WebastoConnectUpdateCoordinator
 from .const import DOMAIN
 
 
+def webasto_device_name(device: WebastoDevice, fallback_name: str | None = None) -> str:
+    """Return the configured device name."""
+    for data in (getattr(device, "dev_data", None), getattr(device, "app_data", None)):
+        if not isinstance(data, dict):
+            continue
+        if name := data.get("name") or data.get("alias"):
+            return str(name)
+
+    if fallback_name:
+        return fallback_name
+
+    return device.name
+
+
 @dataclass(frozen=True)
 class WebastoConnectBaseEntityDescriptionMixin:
     """Describes a basic Webasto entity."""
@@ -96,7 +110,9 @@ class WebastoBaseEntity(CoordinatorEntity[DataUpdateCoordinator[None]]):
         self._device_id = device_id
         self._cloud: WebastoConnect = coordinator.cloud
 
-        if hasattr(self.entity_description, "name_fn") and not isinstance(self.entity_description.name_fn, type(None)):  # type: ignore
+        if hasattr(self.entity_description, "name_fn") and not isinstance(
+            self.entity_description.name_fn, type(None)
+        ):  # type: ignore
             self._attr_name = self.entity_description.name_fn(  # type: ignore
                 self._cloud.devices[self._device_id]
             )
@@ -111,7 +127,7 @@ class WebastoBaseEntity(CoordinatorEntity[DataUpdateCoordinator[None]]):
 
         self._attr_device_info = {
             "identifiers": {(DOMAIN, str(self._device_id))},
-            "name": self._cloud.devices[self._device_id].name,
+            "name": self._device_name,
             "model": "ThermoConnect",
             "manufacturer": "Webasto",
             "hw_version": settings.get("hw_version", "Unknown"),
@@ -123,6 +139,13 @@ class WebastoBaseEntity(CoordinatorEntity[DataUpdateCoordinator[None]]):
     def _device(self) -> WebastoDevice:
         """Return the current device model for this entity."""
         return self._cloud.devices[self._device_id]
+
+    @property
+    def _device_name(self) -> str:
+        """Return the configured device name."""
+        coordinator = getattr(self, "coordinator", None)
+        device_names = getattr(coordinator, "device_names", {})
+        return webasto_device_name(self._device, device_names.get(str(self._device_id)))
 
     @property
     def _is_device_connected(self) -> bool:

--- a/custom_components/webastoconnect/binary_sensor.py
+++ b/custom_components/webastoconnect/binary_sensor.py
@@ -36,7 +36,7 @@ BINARY_SENSORS = [
         icon_on="mdi:map-marker",
         icon_off="mdi:map-marker-off",
         entity_registry_enabled_default=False,
-    )
+    ),
 ]
 
 
@@ -76,9 +76,7 @@ class WebastoConnectBinarySensor(
         super().__init__(device_id, coordinator, description)
 
         self.entity_id = binary_sensor.ENTITY_ID_FORMAT.format(
-            util_slugify(
-                f"{self._cloud.devices[self._device_id].name} {self._attr_name}"
-            )
+            util_slugify(f"{self._device_name} {self._attr_name}")
         )
 
         self._attr_is_on = self.entity_description.value_fn(  # type: ignore

--- a/custom_components/webastoconnect/config_flow.py
+++ b/custom_components/webastoconnect/config_flow.py
@@ -1,12 +1,14 @@
 """Config flow for setting up the integration."""
 
 import logging
+from datetime import datetime
 from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
+from homeassistant.loader import async_get_integration
 from pywebasto import WebastoConnect
 from pywebasto.exceptions import InvalidRequestException, UnauthorizedException
 
@@ -21,6 +23,7 @@ except ImportError:
     InvalidResponseException = InvalidRequestException
     TooManyRequestsException = InvalidRequestException
 
+from .api import _credential_callbacks
 from .const import DOMAIN
 
 LOGGER = logging.getLogger(__name__)
@@ -52,13 +55,18 @@ class WebastoConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
+            integration = await async_get_integration(self.hass, DOMAIN)
             if any(
                 entry.data[CONF_EMAIL] == user_input[CONF_EMAIL]
                 for entry in self._async_current_entries()
             ):
                 return self.async_abort(reason="already_configured")
 
-            webasto = WebastoConnect(user_input[CONF_EMAIL], user_input[CONF_PASSWORD])
+            webasto = WebastoConnect(
+                username=user_input[CONF_EMAIL],
+                password=user_input[CONF_PASSWORD],
+                client_info=f"HomeAssistant-Webasto {integration.version} {int(datetime.now().timestamp())}",
+            )
             try:
                 await webasto.connect()
                 LOGGER.debug("Authorization OK")
@@ -106,7 +114,17 @@ class WebastoConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            webasto = WebastoConnect(user_input[CONF_EMAIL], user_input[CONF_PASSWORD])
+            integration = await async_get_integration(self.hass, DOMAIN)
+            credential_load, credential_save = _credential_callbacks(
+                self.hass, reauth_entry
+            )
+            webasto = WebastoConnect(
+                username=user_input[CONF_EMAIL],
+                password=user_input[CONF_PASSWORD],
+                credential_load=credential_load,
+                credential_save=credential_save,
+                client_info=f"HomeAssistant-Webasto {integration.version} {int(datetime.now().timestamp())}",
+            )
             try:
                 await webasto.connect()
                 LOGGER.debug("Re-authorization OK")
@@ -161,7 +179,17 @@ class WebastoConnectOptionsFlow(config_entries.OptionsFlow):
         errors = {}
 
         if user_input is not None:
-            webasto = WebastoConnect(user_input[CONF_EMAIL], user_input[CONF_PASSWORD])
+            integration = await async_get_integration(self.hass, DOMAIN)
+            credential_load, credential_save = _credential_callbacks(
+                self.hass, self.config_entry
+            )
+            webasto = WebastoConnect(
+                username=user_input[CONF_EMAIL],
+                password=user_input[CONF_PASSWORD],
+                credential_load=credential_load,
+                credential_save=credential_save,
+                client_info=f"HomeAssistant-Webasto {integration.version} {int(datetime.now().timestamp())}",
+            )
             try:
                 await webasto.connect()
                 LOGGER.debug("Authorization OK")

--- a/custom_components/webastoconnect/device_tracker.py
+++ b/custom_components/webastoconnect/device_tracker.py
@@ -51,9 +51,7 @@ class WebastoConnectDeviceTracker(WebastoBaseEntity, TrackerEntity):
         super().__init__(device_id, coordinator, description)
 
         self.entity_id = device_tracker.ENTITY_ID_FORMAT.format(  # type: ignore
-            util_slugify(
-                f"{self._cloud.devices[self._device_id].name} {self._attr_name}"
-            )
+            util_slugify(f"{self._device_name} {self._attr_name}")
         )
 
         location = self._location_data

--- a/custom_components/webastoconnect/manifest.json
+++ b/custom_components/webastoconnect/manifest.json
@@ -13,7 +13,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/MTrab/webastoconnect/issues",
     "requirements": [
-        "pywebasto @ git+https://github.com/mtrab/pywebasto.git@enhancement/module-rewrite"
+        "pywebasto@git+https://github.com/mtrab/pywebasto.git@enhancement/module-rewrite"
     ],
     "version": "1.1.2"
 }

--- a/custom_components/webastoconnect/manifest.json
+++ b/custom_components/webastoconnect/manifest.json
@@ -13,7 +13,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/MTrab/webastoconnect/issues",
     "requirements": [
-        "pywebasto==2.0.4"
+        "pywebasto @ git+https://github.com/mtrab/pywebasto.git@enhancement/module-rewrite"
     ],
     "version": "1.1.2"
 }

--- a/custom_components/webastoconnect/number.py
+++ b/custom_components/webastoconnect/number.py
@@ -80,9 +80,7 @@ class WebastoConnectNumber(WebastoBaseEntity, NumberEntity):
             )
 
         self.entity_id = number.ENTITY_ID_FORMAT.format(
-            util_slugify(
-                f"{self._cloud.devices[self._device_id].name} {self._attr_name}"
-            )
+            util_slugify(f"{self._device_name} {self._attr_name}")
         )
 
     @property

--- a/custom_components/webastoconnect/repairs.py
+++ b/custom_components/webastoconnect/repairs.py
@@ -1,0 +1,55 @@
+"""Repairs for Webasto Connect."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+
+class WebastoReloadRepairFlow(RepairsFlow):
+    """Handle a repair flow that reloads the config entry."""
+
+    def __init__(self, entry_id: str) -> None:
+        """Initialize the repair flow."""
+        self.entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirmation step."""
+        if user_input is not None:
+            self.hass.config_entries.async_schedule_reload(self.entry_id)
+            return self.async_create_entry(data={})
+
+        issue_registry = ir.async_get(self.hass)
+        description_placeholders = None
+        if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
+            description_placeholders = issue.translation_placeholders
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders=description_placeholders,
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create a repair flow."""
+    assert data is not None
+    entry_id = data["entry_id"]
+    assert isinstance(entry_id, str)
+    return WebastoReloadRepairFlow(entry_id)

--- a/custom_components/webastoconnect/sensor.py
+++ b/custom_components/webastoconnect/sensor.py
@@ -60,6 +60,7 @@ def _main_output_end_name(webasto) -> str:
         return f"{output_name} ends"
     return "Output ends"
 
+
 def _extract_simple_timers(webasto: Any) -> list[dict[str, Any]]:
     """Extract `simple` timers (heater + ventilation) from latest API payload."""
     last_data = getattr(webasto, "last_data", None)
@@ -209,6 +210,8 @@ def _next_timer_sensor_payload(
         "next_timer": next_timer,
         "timers": timer_items,
     }
+
+
 SENSORS = [
     WebastoConnectSensorEntityDescription(
         key="temperature",
@@ -312,9 +315,7 @@ class WebastoConnectSensor(WebastoBaseEntity, SensorEntity):
             )
 
         self.entity_id = sensor.ENTITY_ID_FORMAT.format(
-            util_slugify(
-                f"{self._cloud.devices[self._device_id].name} {self._attr_name}"
-            )
+            util_slugify(f"{self._device_name} {self._attr_name}")
         )
 
     @callback

--- a/custom_components/webastoconnect/services.py
+++ b/custom_components/webastoconnect/services.py
@@ -91,9 +91,7 @@ _BASE_SCHEMA = vol.Schema({vol.Required(ATTR_DEVICE_ID): cv.string})
 _CREATE_TIMER_SCHEMA = _BASE_SCHEMA.extend(
     {
         vol.Required(ATTR_START_TIME): cv.string,
-        vol.Required(ATTR_DURATION_MINUTES): vol.All(
-            vol.Coerce(int), vol.Range(min=1)
-        ),
+        vol.Required(ATTR_DURATION_MINUTES): vol.All(vol.Coerce(int), vol.Range(min=1)),
         vol.Optional(ATTR_REPEAT_DAYS, default=[]): [vol.In(tuple(WEEKDAY_TO_MASK))],
         vol.Optional(ATTR_REPEAT): vol.All(vol.Coerce(int), vol.Range(min=0)),
         vol.Optional(ATTR_ENABLED, default=True): cv.boolean,
@@ -113,9 +111,7 @@ _UPDATE_TIMER_SCHEMA = _BASE_SCHEMA.extend(
         vol.Optional(ATTR_LINE, default=LINE_HEATER): vol.In(VALID_TIMER_LINES),
         vol.Required(ATTR_TIMER_INDEX): vol.All(vol.Coerce(int), vol.Range(min=0)),
         vol.Optional(ATTR_START_TIME): cv.string,
-        vol.Optional(ATTR_DURATION_MINUTES): vol.All(
-            vol.Coerce(int), vol.Range(min=1)
-        ),
+        vol.Optional(ATTR_DURATION_MINUTES): vol.All(vol.Coerce(int), vol.Range(min=1)),
         vol.Optional(ATTR_REPEAT_DAYS): [vol.In(tuple(WEEKDAY_TO_MASK))],
         vol.Optional(ATTR_REPEAT): vol.All(vol.Coerce(int), vol.Range(min=0)),
         vol.Optional(ATTR_ENABLED): cv.boolean,
@@ -328,7 +324,9 @@ def _coerce_timer(
     start = data.get(ATTR_START, getattr(existing, "start", None))
     if ATTR_START_TIME in data:
         if hass is None:
-            raise HomeAssistantError("hass context is required for start_time conversion")
+            raise HomeAssistantError(
+                "hass context is required for start_time conversion"
+            )
         start = _start_minutes_from_local_time(hass, data.get(ATTR_START_TIME))
 
     duration = data.get(ATTR_DURATION, getattr(existing, "duration", None))
@@ -364,7 +362,11 @@ async def async_create_timer(
     """Create timer by appending to current timer list."""
 
     async def _operation() -> None:
-        output = _output_for_line(line) if line is not None else _active_output_for_device(device)
+        output = (
+            _output_for_line(line)
+            if line is not None
+            else _active_output_for_device(device)
+        )
         timers = await coordinator.cloud.get_timers(device=device, line=output)
         timers.append(timer)
         await coordinator.cloud.save_timers(device=device, timers=timers, line=output)
@@ -503,6 +505,7 @@ async def _async_handle_delete_timer(hass: HomeAssistant, call: ServiceCall) -> 
 
 def async_register_services(hass: HomeAssistant) -> None:
     """Register domain services."""
+
     async def _handle_create(call: ServiceCall) -> None:
         await _async_handle_create_timer(hass, call)
 

--- a/custom_components/webastoconnect/switch.py
+++ b/custom_components/webastoconnect/switch.py
@@ -92,9 +92,7 @@ class WebastoConnectSwitch(WebastoBaseEntity, SwitchEntity):
         self._handle_states()
 
         self.entity_id = switch.ENTITY_ID_FORMAT.format(
-            util_slugify(
-                f"{self._cloud.devices[self._device_id].name} {self._attr_name}"
-            )
+            util_slugify(f"{self._device_name} {self._attr_name}")
         )
 
     @callback

--- a/custom_components/webastoconnect/translations/cs.json
+++ b/custom_components/webastoconnect/translations/cs.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Zařízení Webasto Connect vyžaduje schválení",
-            "description": "Před pokračováním v nastavení schvalte požadavek na propojení ThermoConnect v aplikaci Webasto. Čekající zařízení: {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/cs.json
+++ b/custom_components/webastoconnect/translations/cs.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Zařízení Webasto Connect vyžaduje schválení",
+            "description": "Před pokračováním v nastavení schvalte požadavek na propojení ThermoConnect v aplikaci Webasto. Čekající zařízení: {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Pokračovat v nastavení Webasto Connect",
+                        "description": "Po schválení požadavku na propojení ThermoConnect v aplikaci Webasto pokračujte opětovným načtením integrace. Čekající zařízení: {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Tento účet je již nakonfigurován",

--- a/custom_components/webastoconnect/translations/da.json
+++ b/custom_components/webastoconnect/translations/da.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Webasto Connect-enhed kræver godkendelse",
+            "description": "Godkend ThermoConnect-tilknytningsanmodningen i Webasto-appen, før opsætningen fortsættes. Afventende enhed(er): {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Fortsæt opsætning af Webasto Connect",
+                        "description": "Når ThermoConnect-tilknytningsanmodningen er godkendt i Webasto-appen, kan du fortsætte for at genindlæse integrationen. Afventende enhed(er): {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Denne konto er allerede registreret",

--- a/custom_components/webastoconnect/translations/da.json
+++ b/custom_components/webastoconnect/translations/da.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Webasto Connect-enhed kræver godkendelse",
-            "description": "Godkend ThermoConnect-tilknytningsanmodningen i Webasto-appen, før opsætningen fortsættes. Afventende enhed(er): {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/de.json
+++ b/custom_components/webastoconnect/translations/de.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Webasto Connect-Gerät erfordert Genehmigung",
+            "description": "Genehmige die ThermoConnect-Verknüpfungsanfrage in der Webasto-App, bevor die Einrichtung fortgesetzt wird. Ausstehende Geräte: {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Webasto Connect-Einrichtung fortsetzen",
+                        "description": "Nachdem du die ThermoConnect-Verknüpfungsanfrage in der Webasto-App genehmigt hast, fahre fort, um die Integration neu zu laden. Ausstehende Geräte: {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Dieses Konto ist bereits eingerichtet",

--- a/custom_components/webastoconnect/translations/de.json
+++ b/custom_components/webastoconnect/translations/de.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Webasto Connect-Gerät erfordert Genehmigung",
-            "description": "Genehmige die ThermoConnect-Verknüpfungsanfrage in der Webasto-App, bevor die Einrichtung fortgesetzt wird. Ausstehende Geräte: {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/en.json
+++ b/custom_components/webastoconnect/translations/en.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Webasto Connect device approval required",
-            "description": "Approve the ThermoConnect association request in the Webasto app before continuing setup. Pending device(s): {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/en.json
+++ b/custom_components/webastoconnect/translations/en.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Webasto Connect device approval required",
+            "description": "Approve the ThermoConnect association request in the Webasto app before continuing setup. Pending device(s): {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Continue Webasto Connect setup",
+                        "description": "After approving the ThermoConnect association request in the Webasto app, continue to reload the integration. Pending device(s): {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "This account is already configured",

--- a/custom_components/webastoconnect/translations/es.json
+++ b/custom_components/webastoconnect/translations/es.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Se requiere aprobar el dispositivo Webasto Connect",
+            "description": "Aprueba la solicitud de asociación de ThermoConnect en la aplicación Webasto antes de continuar con la configuración. Dispositivo(s) pendiente(s): {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Continuar la configuración de Webasto Connect",
+                        "description": "Después de aprobar la solicitud de asociación de ThermoConnect en la aplicación Webasto, continúa para recargar la integración. Dispositivo(s) pendiente(s): {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Esta cuenta ya está configurada",

--- a/custom_components/webastoconnect/translations/es.json
+++ b/custom_components/webastoconnect/translations/es.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Se requiere aprobar el dispositivo Webasto Connect",
-            "description": "Aprueba la solicitud de asociación de ThermoConnect en la aplicación Webasto antes de continuar con la configuración. Dispositivo(s) pendiente(s): {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/fi.json
+++ b/custom_components/webastoconnect/translations/fi.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Webasto Connect -laite vaatii hyväksynnän",
-            "description": "Hyväksy ThermoConnect-yhdistämispyyntö Webasto-sovelluksessa ennen määrityksen jatkamista. Odottavat laitteet: {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/fi.json
+++ b/custom_components/webastoconnect/translations/fi.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Webasto Connect -laite vaatii hyväksynnän",
+            "description": "Hyväksy ThermoConnect-yhdistämispyyntö Webasto-sovelluksessa ennen määrityksen jatkamista. Odottavat laitteet: {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Jatka Webasto Connectin määritystä",
+                        "description": "Kun ThermoConnect-yhdistämispyyntö on hyväksytty Webasto-sovelluksessa, jatka ladataksesi integraation uudelleen. Odottavat laitteet: {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Tämä tili on jo määritetty",

--- a/custom_components/webastoconnect/translations/fr.json
+++ b/custom_components/webastoconnect/translations/fr.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Approbation de l'appareil Webasto Connect requise",
-            "description": "Approuvez la demande d'association ThermoConnect dans l'application Webasto avant de poursuivre la configuration. Appareil(s) en attente : {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/fr.json
+++ b/custom_components/webastoconnect/translations/fr.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Approbation de l'appareil Webasto Connect requise",
+            "description": "Approuvez la demande d'association ThermoConnect dans l'application Webasto avant de poursuivre la configuration. Appareil(s) en attente : {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Continuer la configuration de Webasto Connect",
+                        "description": "Après avoir approuvé la demande d'association ThermoConnect dans l'application Webasto, continuez pour recharger l'intégration. Appareil(s) en attente : {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Ce compte est déjà configuré",

--- a/custom_components/webastoconnect/translations/nb.json
+++ b/custom_components/webastoconnect/translations/nb.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Webasto Connect-enhet krever godkjenning",
+            "description": "Godkjenn ThermoConnect-tilknytningsforespørselen i Webasto-appen før oppsettet fortsetter. Ventende enhet(er): {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Fortsett oppsett av Webasto Connect",
+                        "description": "Når ThermoConnect-tilknytningsforespørselen er godkjent i Webasto-appen, kan du fortsette for å laste integrasjonen på nytt. Ventende enhet(er): {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Denne kontoen er allerede konfigurert",

--- a/custom_components/webastoconnect/translations/nb.json
+++ b/custom_components/webastoconnect/translations/nb.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Webasto Connect-enhet krever godkjenning",
-            "description": "Godkjenn ThermoConnect-tilknytningsforespørselen i Webasto-appen før oppsettet fortsetter. Ventende enhet(er): {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/nl.json
+++ b/custom_components/webastoconnect/translations/nl.json
@@ -3,7 +3,6 @@
     "issues": {
         "pending_approval": {
             "title": "Webasto Connect-apparaat vereist goedkeuring",
-            "description": "Keur het ThermoConnect-koppelingsverzoek goed in de Webasto-app voordat de configuratie wordt voortgezet. Wachtende apparaat/apparaten: {devices}",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/webastoconnect/translations/nl.json
+++ b/custom_components/webastoconnect/translations/nl.json
@@ -1,5 +1,19 @@
 {
     "title": "Webasto Connect (ThermoConnect)",
+    "issues": {
+        "pending_approval": {
+            "title": "Webasto Connect-apparaat vereist goedkeuring",
+            "description": "Keur het ThermoConnect-koppelingsverzoek goed in de Webasto-app voordat de configuratie wordt voortgezet. Wachtende apparaat/apparaten: {devices}",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Webasto Connect-configuratie voortzetten",
+                        "description": "Nadat je het ThermoConnect-koppelingsverzoek in de Webasto-app hebt goedgekeurd, ga je verder om de integratie opnieuw te laden. Wachtende apparaat/apparaten: {devices}"
+                    }
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Dit account is al geconfigureerd",

--- a/tests/test_api_coordinator.py
+++ b/tests/test_api_coordinator.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -13,7 +13,83 @@ from pywebasto.exceptions import (
     UnauthorizedException,
 )
 
-from custom_components.webastoconnect.api import WebastoConnectUpdateCoordinator
+from custom_components.webastoconnect.api import (
+    SCAN_INTERVAL,
+    WebastoConnectUpdateCoordinator,
+    _credential_callbacks,
+    _credential_store_path,
+)
+
+
+def test_scan_interval_is_60_seconds() -> None:
+    """Coordinator polling interval should be one minute."""
+    assert SCAN_INTERVAL.total_seconds() == 60
+
+
+def test_credential_store_path_uses_config_entry_id() -> None:
+    """Credential store path should be unique per config entry."""
+    hass = SimpleNamespace(config=SimpleNamespace(path=lambda *parts: "/".join(parts)))
+    entry = SimpleNamespace(entry_id="entry-1")
+
+    assert _credential_store_path(hass, entry) == ".storage/webasto_entry-1.json"
+
+
+@pytest.mark.asyncio
+async def test_credential_callbacks_store_credentials_by_entry_id(tmp_path) -> None:
+    """Credential callbacks should read and write the per-entry credential file."""
+
+    async def async_add_executor_job(func, *args):
+        return func(*args)
+
+    hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda *parts: str(tmp_path.joinpath(*parts))),
+        async_add_executor_job=async_add_executor_job,
+    )
+    entry = SimpleNamespace(entry_id="entry-1")
+    credentials = SimpleNamespace(client_id="client", client_secret="secret")
+    credential_load, credential_save = _credential_callbacks(hass, entry)
+
+    assert await credential_load() is None
+
+    await credential_save(credentials)
+
+    assert await credential_load() == {
+        "client_id": "client",
+        "client_secret": "secret",
+    }
+    assert (tmp_path / ".storage" / "webasto_entry-1.json").exists()
+
+
+def test_update_coordinator_uses_entry_credential_callbacks(monkeypatch) -> None:
+    """Update coordinator should pass per-entry credential callbacks."""
+    webasto = Mock()
+    monkeypatch.setattr("custom_components.webastoconnect.api.WebastoConnect", webasto)
+    monkeypatch.setattr(
+        "custom_components.webastoconnect.api.DataUpdateCoordinator.__init__",
+        lambda *args, **kwargs: None,
+    )
+    hass = SimpleNamespace(config=SimpleNamespace(path=lambda *parts: "/".join(parts)))
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        data={"email": "user@test", "password": "pw"},
+        options={},
+    )
+
+    WebastoConnectUpdateCoordinator(hass, entry, "1.2.3")
+
+    webasto.assert_called_once()
+    assert webasto.call_args.kwargs["username"] == "user@test"
+    assert webasto.call_args.kwargs["password"] == "pw"
+    assert webasto.call_args.kwargs["client_info"].startswith(
+        "HomeAssistant-Webasto 1.2.3 "
+    )
+    assert set(webasto.call_args.kwargs) == {
+        "username",
+        "password",
+        "credential_load",
+        "credential_save",
+        "client_info",
+    }
 
 
 def _build_coordinator(update_mock: AsyncMock) -> WebastoConnectUpdateCoordinator:

--- a/tests/test_base_entity.py
+++ b/tests/test_base_entity.py
@@ -1,0 +1,50 @@
+"""Tests for Webasto base entity behavior."""
+
+from types import SimpleNamespace
+
+from homeassistant.util import slugify as util_slugify
+
+from custom_components.webastoconnect.base import WebastoBaseEntity, webasto_device_name
+from custom_components.webastoconnect.sensor import WebastoConnectSensor
+
+
+def test_device_name_uses_app_alias_when_device_name_is_id() -> None:
+    """Device info name should use the approved app name when available."""
+    entity = object.__new__(WebastoBaseEntity)
+    device = SimpleNamespace(
+        device_id="123",
+        name="123",
+        app_data={"alias": "Car"},
+    )
+    entity._device_id = "123"
+    entity._cloud = SimpleNamespace(devices={"123": device})
+
+    assert entity._device_name == "Car"
+
+
+def test_device_name_uses_fallback_name() -> None:
+    """Device name should use webapi fallback when app data has no name."""
+    device = SimpleNamespace(
+        device_id="123",
+        name="123",
+        app_data={"id": "123"},
+    )
+
+    assert webasto_device_name(device, "Car") == "Car"
+
+
+def test_entity_id_uses_app_alias_when_device_name_is_id() -> None:
+    """Entity id should use the configured device name."""
+    sensor = object.__new__(WebastoConnectSensor)
+    device = SimpleNamespace(
+        device_id="123",
+        name="123",
+        app_data={"alias": "Car"},
+    )
+    sensor._device_id = "123"
+    sensor._cloud = SimpleNamespace(devices={"123": device})
+    sensor._attr_name = "Temperature"
+
+    entity_id = "sensor." + util_slugify(f"{sensor._device_name} {sensor._attr_name}")
+
+    assert entity_id == "sensor.car_temperature"

--- a/tests/test_options_reload_flow.py
+++ b/tests/test_options_reload_flow.py
@@ -11,7 +11,18 @@ from pywebasto.exceptions import (
 )
 
 import custom_components.webastoconnect as integration
+import custom_components.webastoconnect.config_flow as config_flow
 from custom_components.webastoconnect.config_flow import WebastoConnectOptionsFlow
+
+
+@pytest.fixture(autouse=True)
+def mock_integration_version(monkeypatch) -> None:
+    """Provide integration metadata in options flow tests."""
+    monkeypatch.setattr(
+        config_flow,
+        "async_get_integration",
+        AsyncMock(return_value=SimpleNamespace(version="test")),
+    )
 
 
 @pytest.mark.asyncio
@@ -82,12 +93,14 @@ async def test_options_flow_creates_entry_after_successful_auth(monkeypatch) -> 
     """Options flow should create entry directly after successful auth."""
     connect_mock = AsyncMock()
     close_mock = AsyncMock()
+    init_mock = Mock()
 
     class FakeWebasto:
         """Minimal fake Webasto client for options flow tests."""
 
         def __init__(self, *args, **kwargs) -> None:
             """Initialize fake client."""
+            init_mock(*args, **kwargs)
 
         async def connect(self) -> None:
             """Simulate successful auth."""
@@ -103,17 +116,26 @@ async def test_options_flow_creates_entry_after_successful_auth(monkeypatch) -> 
     )
 
     flow = object.__new__(WebastoConnectOptionsFlow)
-    config_entry = SimpleNamespace(data={}, options={})
+    config_entry = SimpleNamespace(entry_id="entry-1", data={}, options={})
     flow.hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda *parts: "/".join(parts)),
         config_entries=SimpleNamespace(
             async_get_known_entry=Mock(return_value=config_entry)
-        )
+        ),
     )
     flow.handler = "entry-1"
     flow.async_create_entry = Mock(return_value={"type": "create_entry"})
 
     result = await flow.async_step_init({"email": "user@test", "password": "pw"})
 
+    init_mock.assert_called_once()
+    assert init_mock.call_args.kwargs["username"] == "user@test"
+    assert init_mock.call_args.kwargs["password"] == "pw"
+    assert init_mock.call_args.kwargs["client_info"].startswith(
+        "HomeAssistant-Webasto test "
+    )
+    assert "credential_load" in init_mock.call_args.kwargs
+    assert "credential_save" in init_mock.call_args.kwargs
     connect_mock.assert_awaited_once()
     close_mock.assert_awaited_once()
     flow.async_create_entry.assert_called_once_with(
@@ -147,11 +169,12 @@ async def test_options_flow_returns_error_on_invalid_auth(monkeypatch) -> None:
     )
 
     flow = object.__new__(WebastoConnectOptionsFlow)
-    config_entry = SimpleNamespace(data={}, options={})
+    config_entry = SimpleNamespace(entry_id="entry-1", data={}, options={})
     flow.hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda *parts: "/".join(parts)),
         config_entries=SimpleNamespace(
             async_get_known_entry=Mock(return_value=config_entry)
-        )
+        ),
     )
     flow.handler = "entry-1"
     flow.async_show_form = Mock(return_value={"type": "form"})
@@ -191,11 +214,12 @@ async def test_options_flow_returns_error_on_connection_validation_failure(
     )
 
     flow = object.__new__(WebastoConnectOptionsFlow)
-    config_entry = SimpleNamespace(data={}, options={})
+    config_entry = SimpleNamespace(entry_id="entry-1", data={}, options={})
     flow.hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda *parts: "/".join(parts)),
         config_entries=SimpleNamespace(
             async_get_known_entry=Mock(return_value=config_entry)
-        )
+        ),
     )
     flow.handler = "entry-1"
     flow.async_show_form = Mock(return_value={"type": "form"})
@@ -233,11 +257,12 @@ async def test_options_flow_returns_error_on_rate_limit(monkeypatch) -> None:
     )
 
     flow = object.__new__(WebastoConnectOptionsFlow)
-    config_entry = SimpleNamespace(data={}, options={})
+    config_entry = SimpleNamespace(entry_id="entry-1", data={}, options={})
     flow.hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda *parts: "/".join(parts)),
         config_entries=SimpleNamespace(
             async_get_known_entry=Mock(return_value=config_entry)
-        )
+        ),
     )
     flow.handler = "entry-1"
     flow.async_show_form = Mock(return_value={"type": "form"})

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,26 @@
+"""Tests for Webasto repairs."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.webastoconnect.repairs import async_create_fix_flow
+
+
+@pytest.mark.asyncio
+async def test_pending_approval_repair_reloads_entry() -> None:
+    """Repair flow should reload the config entry when continued."""
+    scheduled: list[str] = []
+    flow = await async_create_fix_flow(
+        SimpleNamespace(),
+        "pending_approval",
+        {"entry_id": "entry-1"},
+    )
+    flow.hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_schedule_reload=scheduled.append)
+    )
+
+    result = await flow.async_step_confirm({})
+
+    assert scheduled == ["entry-1"]
+    assert result["type"] == "create_entry"

--- a/tests/test_setup_initial_refresh.py
+++ b/tests/test_setup_initial_refresh.py
@@ -1,11 +1,15 @@
 """Tests for setup bootstrap refresh behavior."""
 
 from types import SimpleNamespace
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 from homeassistant.const import CONF_EMAIL
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+)
 from pywebasto.exceptions import (
     InvalidRequestException,
     TooManyRequestsException,
@@ -15,11 +19,28 @@ from pywebasto.exceptions import (
 import custom_components.webastoconnect as integration
 
 
+@pytest.fixture(autouse=True)
+def mock_issue_delete(monkeypatch) -> None:
+    """Avoid using the real issue registry in setup unit tests."""
+    monkeypatch.setattr(integration.ir, "async_delete_issue", Mock())
+    monkeypatch.setattr(
+        integration, "_async_webapi_device_names", AsyncMock(return_value={})
+    )
+
+
 def _mock_hass_for_setup() -> SimpleNamespace:
     """Build a minimal hass mock compatible with integration._async_setup."""
+
+    async def async_add_executor_job(func, *args):
+        if getattr(func, "__name__", "") == "ensure_card_installed":
+            return (False, None, None)
+        return func(*args)
+
     return SimpleNamespace(
-        async_add_executor_job=AsyncMock(return_value=(False, None, None)),
-        config=SimpleNamespace(path=lambda *_args, **_kwargs: "/tmp"),
+        async_add_executor_job=async_add_executor_job,
+        config=SimpleNamespace(
+            path=lambda *parts, **_kwargs: str(Path("/tmp", *parts))
+        ),
         data={},
     )
 
@@ -51,6 +72,10 @@ async def test_setup_skips_first_refresh_when_connect_hydrates_devices(
     )
     migrate_mock = AsyncMock()
     monkeypatch.setattr(integration, "_async_migrate_unique_ids", migrate_mock)
+    update_device_name_mock = AsyncMock()
+    monkeypatch.setattr(
+        integration, "_async_update_device_registry_name", update_device_name_mock
+    )
 
     hass = _mock_hass_for_setup()
     entry = SimpleNamespace(entry_id="entry-1", data={CONF_EMAIL: "a@b.c"}, options={})
@@ -63,6 +88,7 @@ async def test_setup_skips_first_refresh_when_connect_hydrates_devices(
     coordinator.async_set_updated_data.assert_called_once_with(None)
     coordinator.async_config_entry_first_refresh.assert_not_awaited()
     migrate_mock.assert_awaited_once_with(hass, 1, "Heater", entry)
+    update_device_name_mock.assert_awaited_once_with(hass, 1, "Heater")
 
 
 @pytest.mark.asyncio
@@ -168,7 +194,7 @@ async def test_setup_closes_client_when_connect_temporarily_fails(monkeypatch) -
     hass = _mock_hass_for_setup()
     entry = SimpleNamespace(entry_id="entry-1", data={CONF_EMAIL: "a@b.c"}, options={})
 
-    with pytest.raises(ConfigEntryNotReady):
+    with pytest.raises(ConfigEntryError):
         await integration._async_setup(hass, entry)
 
     created[0].cloud.close.assert_awaited_once()
@@ -204,8 +230,77 @@ async def test_setup_closes_client_when_connect_is_rate_limited(monkeypatch) -> 
     hass = _mock_hass_for_setup()
     entry = SimpleNamespace(entry_id="entry-1", data={CONF_EMAIL: "a@b.c"}, options={})
 
-    with pytest.raises(ConfigEntryNotReady) as exc_info:
+    with pytest.raises(ConfigEntryError) as exc_info:
         await integration._async_setup(hass, entry)
 
     assert "Rate limited" in str(exc_info.value)
     created[0].cloud.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_stops_when_device_is_pending_approval(monkeypatch) -> None:
+    """Pending approval should stop setup and create a repair issue."""
+    created: list[SimpleNamespace] = []
+    issues: list[dict] = []
+    deleted_issues: list[tuple] = []
+    device = SimpleNamespace(name="Heater", device_id=1, pending_approval=True)
+
+    def coordinator_factory(*_args, **_kwargs):
+        coordinator = SimpleNamespace(
+            cloud=SimpleNamespace(
+                connect=AsyncMock(),
+                close=AsyncMock(),
+                devices={1: device},
+            ),
+            async_config_entry_first_refresh=AsyncMock(),
+            async_set_updated_data=Mock(),
+        )
+        created.append(coordinator)
+        return coordinator
+
+    def create_issue(*args, **kwargs):
+        issues.append({"args": args, "kwargs": kwargs})
+
+    def delete_issue(*args):
+        deleted_issues.append(args)
+
+    monkeypatch.setattr(
+        integration, "WebastoConnectUpdateCoordinator", coordinator_factory
+    )
+    monkeypatch.setattr(
+        integration,
+        "async_get_integration",
+        AsyncMock(return_value=SimpleNamespace(version="test", file_path="/tmp")),
+    )
+    monkeypatch.setattr(integration.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(integration.ir, "async_delete_issue", delete_issue)
+
+    hass = _mock_hass_for_setup()
+    entry = SimpleNamespace(entry_id="entry-1", data={CONF_EMAIL: "a@b.c"}, options={})
+
+    with pytest.raises(ConfigEntryError) as exc_info:
+        await integration._async_setup(hass, entry)
+
+    assert "pending approval" in str(exc_info.value)
+    created[0].cloud.close.assert_awaited_once()
+    created[0].async_set_updated_data.assert_not_called()
+    created[0].async_config_entry_first_refresh.assert_not_awaited()
+    assert issues[0]["kwargs"]["is_fixable"] is True
+    assert issues[0]["kwargs"]["data"] == {"entry_id": "entry-1"}
+    assert issues[0]["kwargs"]["translation_key"] == "pending_approval"
+    assert issues[0]["kwargs"]["translation_placeholders"] == {"devices": "Heater"}
+    assert not deleted_issues
+
+
+def test_device_names_from_webapi_data() -> None:
+    """Device names should be extracted from webapi data."""
+    data = {
+        "id": "123",
+        "alias": "Car",
+        "account_info": {"devices": [["456", "Van"]]},
+    }
+
+    assert integration._device_names_from_webapi_data(data) == {
+        "123": "Car",
+        "456": "Van",
+    }


### PR DESCRIPTION
## Description
- Update the integration to use the pywebasto module rewrite branch for beta testing.
- Store pywebasto app credentials per config entry under `.storage/webasto_<entry_id>.json` using async credential callbacks.
- Keep normal polling at 60 seconds and avoid duplicate setup refresh when `connect()` already hydrates devices.
- Stop setup while a device association is pending approval and expose a translatable repair flow to reload after approval.
- Preserve Webasto device names from API data in entity IDs and the Home Assistant device registry.
- Pass client info with the current integration version during setup, config flow, reauth, and options validation.

## Test strategy
- `ruff check .`
- `pytest` (87 passed)

## Known limitations
- `manifest.json` intentionally points to `pywebasto @ git+https://github.com/mtrab/pywebasto.git@enhancement/module-rewrite` for beta testing. This should be changed back to a released PyPI requirement before final merge/release.
- Hardware/cloud behavior still needs drift testing against a real Webasto account/device.