### PR TITLE
Update pywebasto dependency to 3.0.0

### DIFF
--- a/custom_components/webastoconnect/manifest.json
+++ b/custom_components/webastoconnect/manifest.json
@@ -13,7 +13,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/MTrab/webastoconnect/issues",
     "requirements": [
-        "pywebasto@git+https://github.com/mtrab/pywebasto.git@enhancement/module-rewrite"
+        "pywebasto==3.0.0"
     ],
     "version": "1.2.0alpha1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.10.1
 homeassistant==2026.6.2
-pywebasto==2.0.4
+pywebasto==3.0.0
 pytest==9.0.3
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0


### PR DESCRIPTION
## Summary
- update pywebasto runtime requirement to 3.0.0
- update development requirements to match

## Test strategy
- ruff check .
- pytest with pywebasto==3.0.0 installed locally

## Known limitations
- No hardware validation performed.

## Required configuration changes
- None